### PR TITLE
Add `ContextCompat` trait for porting from `anyhow`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ rustversion = "1.0"
 thiserror = "1.0"
 trybuild = { version = "1.0.19", features = ["diff"] }
 backtrace = "0.3.46"
+anyhow = "1.0.28"
 
 [dependencies]
 indenter = "0.1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ backtrace = "0.3.46"
 anyhow = "1.0.28"
 
 [dependencies]
-indenter = "0.1.3"
+indenter = "0.2.0"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/README.md
+++ b/README.md
@@ -170,8 +170,10 @@ The type inference issue is caused by the generic parameter, which isn't
 present in `anyhow::Error`. Specifically, the following works in anyhow:
 
 ```rust
+use anyhow::anyhow;
+
 // Works
-let val = get_optional_val.ok_or_else(|| anyhow!("failed to get value")).unwrap();
+let val = get_optional_val().ok_or_else(|| anyhow!("failed to get value")).unwrap_err();
 ```
 
 Where as with `eyre!` this will fail due to being unable to infer the type for
@@ -179,12 +181,14 @@ the Context parameter. The solution to this problem, should you encounter it,
 is to give the compiler a hint for what type it should be resolving to, either
 via your return type or a type annotation.
 
-```rust
+```rust,compile_fail
+use eyre::eyre;
+
 // Broken
-let val = get_optional_val.ok_or_else(|| eyre!("failed to get value")).unwrap();
+let val = get_optional_val().ok_or_else(|| eyre!("failed to get value")).unwrap();
 
 // Works
-let val: Report = get_optional_val.ok_or_else(|| eyre!("failed to get value")).unwrap();
+let val: Report = get_optional_val().ok_or_else(|| eyre!("failed to get value")).unwrap();
 ```
 
 #### `Context` and `Option`
@@ -209,10 +213,10 @@ let result = opt.context("new error message");
 With `eyre` we want users to write:
 
 ```rust
-use eyre::eyre;
+use eyre::{eyre, Result};
 
 let opt: Option<()> = None;
-let result = opt.ok_or_else(|| eyre!("new error message"));
+let result: Result<()> = opt.ok_or_else(|| eyre!("new error message"));
 ```
 
 However, to help with porting we do provide a `ContextCompat` trait which

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -24,6 +24,26 @@ pub(crate) enum ChainState<'a> {
 }
 
 impl<'a> Chain<'a> {
+    /// Construct an iterator over a chain of errors via the `source` method
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use std::error::Error;
+    /// use std::fmt::{self, Write};
+    /// use eyre::Chain;
+    /// use indenter::indented;
+    ///
+    /// fn report(error: &(dyn Error + 'static), f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    ///     let mut errors = Chain::new(error).enumerate();
+    ///     for (i, error) in errors {
+    ///         writeln!(f)?;
+    ///         write!(indented(f).ind(i), "{}", error)?;
+    ///     }
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn new(head: &'a (dyn StdError + 'static)) -> Self {
         Chain {
             state: ChainState::Linked { next: Some(head) },

--- a/src/error.rs
+++ b/src/error.rs
@@ -96,7 +96,7 @@ where
 
     pub(crate) fn from_adhoc<M>(message: M) -> Self
     where
-        M: Display + Send + Sync + 'static,
+        M: Display + Debug + Send + Sync + 'static,
     {
         use crate::wrapper::MessageError;
         let error: MessageError<M> = MessageError(message);

--- a/src/error.rs
+++ b/src/error.rs
@@ -96,7 +96,7 @@ where
 
     pub(crate) fn from_adhoc<M>(message: M) -> Self
     where
-        M: Display + Debug + Send + Sync + 'static,
+        M: Display + Send + Sync + 'static,
     {
         use crate::wrapper::MessageError;
         let error: MessageError<M> = MessageError(message);

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -6,14 +6,14 @@ impl<C> ErrorImpl<(), C>
 where
     C: EyreContext,
 {
-    pub(crate) fn display(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    pub(crate) fn display(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.context
             .as_ref()
             .map(|context| context.display(self.error(), f))
             .unwrap_or_else(|| std::fmt::Display::fmt(self.error(), f))
     }
 
-    pub(crate) fn debug(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    pub(crate) fn debug(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.context
             .as_ref()
             .map(|context| context.debug(self.error(), f))

--- a/src/kind.rs
+++ b/src/kind.rs
@@ -1,3 +1,4 @@
+#![allow(missing_debug_implementations, missing_docs)]
 // Tagged dispatch mechanism for resolving the behavior of `eyre!($expr)`.
 //
 // When eyre! is given a single expr argument to turn into eyre::Report, we

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -273,6 +273,29 @@
 //! [`tracing_error::SpanTrace`]: https://docs.rs/tracing-error/*/tracing_error/struct.SpanTrace.html
 //! [`stable_eyre`]: https://docs.rs/stable-eyre
 #![doc(html_root_url = "https://docs.rs/eyre/0.4.0")]
+#![warn(
+    missing_debug_implementations,
+    missing_docs,
+    missing_doc_code_examples,
+    rust_2018_idioms,
+    unreachable_pub,
+    bad_style,
+    const_err,
+    dead_code,
+    improper_ctypes,
+    non_shorthand_field_patterns,
+    no_mangle_generic_items,
+    overflowing_literals,
+    path_statements,
+    patterns_in_fns_without_body,
+    private_in_public,
+    unconditional_recursion,
+    unused,
+    unused_allocation,
+    unused_comparisons,
+    unused_parens,
+    while_true
+)]
 #![cfg_attr(backtrace, feature(backtrace))]
 #![cfg_attr(doc_cfg, feature(doc_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
@@ -287,16 +310,16 @@ mod alloc {
     extern crate alloc;
 
     #[cfg(not(feature = "std"))]
-    pub use alloc::boxed::Box;
+    pub(crate) use alloc::boxed::Box;
 
     #[cfg(feature = "std")]
-    pub use std::boxed::Box;
+    pub(crate) use std::boxed::Box;
 
     #[cfg(not(feature = "std"))]
-    pub use alloc::string::String;
+    pub(crate) use alloc::string::String;
 
-    #[cfg(feature = "std")]
-    pub use std::string::String;
+    // #[cfg(feature = "std")]
+    // pub(crate) use std::string::String;
 }
 
 #[macro_use]
@@ -449,6 +472,7 @@ where
 /// use eyre::EyreContext;
 /// # use eyre::Chain;
 /// # use std::error::Error;
+/// use indenter::indented;
 ///
 /// pub struct Context {
 ///     backtrace: Backtrace,
@@ -477,9 +501,9 @@ where
 /// #             for (n, error) in Chain::new(cause).enumerate() {
 /// #                 writeln!(f)?;
 /// #                 if multiple {
-/// #                     write!(indenter::Indented::numbered(f, n), "{}", error)?;
+/// #                     write!(indented(f).ind(n), "{}", error)?;
 /// #                 } else {
-/// #                     write!(indenter::Indented::new(f), "{}", error)?;
+/// #                     write!(indented(f), "{}", error)?;
 /// #                 }
 /// #             }
 /// #         }
@@ -536,9 +560,9 @@ pub trait EyreContext: Sized + Send + Sync + 'static {
     /// #             for (n, error) in Chain::new(cause).enumerate() {
     /// #                 writeln!(f)?;
     /// #                 if multiple {
-    /// #                     write!(indenter::Indented::numbered(f, n), "{}", error)?;
+    /// #                     write!(indenter::indented(f).ind(n), "{}", error)?;
     /// #                 } else {
-    /// #                     write!(indenter::Indented::new(f), "{}", error)?;
+    /// #                     write!(indenter::indented(f), "{}", error)?;
     /// #                 }
     /// #             }
     /// #         }
@@ -561,6 +585,7 @@ pub trait EyreContext: Sized + Send + Sync + 'static {
     /// use eyre::EyreContext;
     /// use eyre::Chain;
     /// use std::error::Error;
+    /// use indenter::indented;
     ///
     /// pub struct Context {
     ///     backtrace: Backtrace,
@@ -594,9 +619,9 @@ pub trait EyreContext: Sized + Send + Sync + 'static {
     ///             for (n, error) in Chain::new(cause).enumerate() {
     ///                 writeln!(f)?;
     ///                 if multiple {
-    ///                     write!(indenter::Indented::numbered(f, n), "{}", error)?;
+    ///                     write!(indented(f).ind(n), "{}", error)?;
     ///                 } else {
-    ///                     write!(indenter::Indented::new(f), "{}", error)?;
+    ///                     write!(indented(f), "{}", error)?;
     ///                 }
     ///             }
     ///         }
@@ -641,6 +666,20 @@ pub struct DefaultContext {
     backtrace: Option<Backtrace>,
 }
 
+impl core::fmt::Debug for DefaultContext {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DefaultContext")
+            .field(
+                "backtrace",
+                match &self.backtrace {
+                    Some(_) => &"Some(Backtrace { ... })",
+                    None => &"None",
+                },
+            )
+            .finish()
+    }
+}
+
 impl EyreContext for DefaultContext {
     #[allow(unused_variables)]
     fn default(error: &(dyn StdError + 'static)) -> Self {
@@ -668,9 +707,9 @@ impl EyreContext for DefaultContext {
             for (n, error) in crate::chain::Chain::new(cause).enumerate() {
                 writeln!(f)?;
                 if multiple {
-                    write!(indenter::Indented::numbered(f, n), "{}", error)?;
+                    write!(indenter::indented(f).ind(n), "{}", error)?;
                 } else {
-                    write!(indenter::Indented::new(f), "{}", error)?;
+                    write!(indenter::indented(f), "{}", error)?;
                 }
             }
         }
@@ -714,6 +753,7 @@ impl EyreContext for DefaultContext {
 /// ```
 #[cfg(feature = "std")]
 #[derive(Clone)]
+#[allow(missing_debug_implementations)]
 pub struct Chain<'a> {
     state: crate::chain::ChainState<'a>,
 }
@@ -927,6 +967,78 @@ where
 
     /// Compatibility re-export of wrap_err_with for interopt with `anyhow`
     fn with_context<D, F>(self, f: F) -> Result<T, Report<C>>
+    where
+        D: Display + Send + Sync + 'static,
+        F: FnOnce() -> D;
+}
+
+/// Provides the `context` method for `Option` when porting from `anyhow`
+///
+/// This trait is sealed and cannot be implemented for types outside of
+/// `eyre`.
+///
+/// ## Why Doesn't `Eyre` impl `WrapErr` for `Option`?
+///
+/// `eyre` doesn't impl `WrapErr` for `Option` because `wrap_err` implies that you're creating a
+/// new error that saves the previous error as its `source`. Calling `wrap_err` on an `Option` is
+/// meaningless because there is no source error. `anyhow` avoids this issue by using a different
+/// mental model where you're adding "context" to an error, though this not a mental model for
+/// error handling that `eyre` agrees with.
+///
+/// Instead, `eyre` encourages users to think of each error as distinct errors, where the previous
+/// error is the context being saved by the new error, which is the inverse mental model. In this
+/// model you're encouraged to use combinators provided by `std` for `Option` to convert an option
+/// to a `Result`
+///
+/// # Example
+///
+/// Instead of:
+///
+/// ```rust
+/// use eyre::ContextCompat;
+///
+/// fn get_thing(mut things: impl Iterator<Item = u32>) -> eyre::Result<u32> {
+///     things
+///         .find(|&thing| thing == 42)
+///         .context("the thing wasnt in the list")
+/// }
+/// ```
+///
+/// We encourage you to use this:
+///
+/// ```rust
+/// use eyre::eyre;
+///
+/// fn get_thing(mut things: impl Iterator<Item = u32>) -> eyre::Result<u32> {
+///     things
+///         .find(|&thing| thing == 42)
+///         .ok_or_else(|| eyre!("the thing wasnt in the list"))
+/// }
+/// ```
+pub trait ContextCompat<T, C>: context::private::Sealed<C>
+where
+    C: EyreContext,
+{
+    /// Compatibility version of `wrap_err` for creating new errors with new source on `Option`
+    /// when porting from `anyhow`
+    fn context<D>(self, msg: D) -> Result<T, Report<C>>
+    where
+        D: Display + Send + Sync + 'static;
+
+    /// Compatibility version of `wrap_err_with` for creating new errors with new source on `Option`
+    /// when porting from `anyhow`
+    fn with_context<D, F>(self, f: F) -> Result<T, Report<C>>
+    where
+        D: Display + Send + Sync + 'static,
+        F: FnOnce() -> D;
+
+    /// Compatibility re-export of `context` for porting from `anyhow` to `eyre`
+    fn wrap_err<D>(self, msg: D) -> Result<T, Report<C>>
+    where
+        D: Display + Send + Sync + 'static;
+
+    /// Compatibility re-export of `with_context` for porting from `anyhow` to `eyre`
+    fn wrap_err_with<D, F>(self, f: F) -> Result<T, Report<C>>
     where
         D: Display + Send + Sync + 'static,
         F: FnOnce() -> D;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,8 +211,11 @@
 //! present in `anyhow::Error`. Specifically, the following works in anyhow:
 //!
 //! ```rust
+//! # fn get_optional_val() -> Option<()> { None };
+//! use anyhow::anyhow;
+//!
 //! // Works
-//! let val = get_optional_val.ok_or_else(|| anyhow!("failed to get value")).unwrap();
+//! let val = get_optional_val().ok_or_else(|| anyhow!("failed to get value")).unwrap_err();
 //! ```
 //!
 //! Where as with `eyre!` this will fail due to being unable to infer the type for
@@ -220,12 +223,15 @@
 //! is to give the compiler a hint for what type it should be resolving to, either
 //! via your return type or a type annotation.
 //!
-//! ```rust
+//! ```rust,compile_fail
+//! use eyre::eyre;
+//!
+//! # fn get_optional_val() -> Option<()> { None };
 //! // Broken
-//! let val = get_optional_val.ok_or_else(|| eyre!("failed to get value")).unwrap();
+//! let val = get_optional_val().ok_or_else(|| eyre!("failed to get value")).unwrap();
 //!
 //! // Works
-//! let val: Report = get_optional_val.ok_or_else(|| eyre!("failed to get value")).unwrap();
+//! let val: Report = get_optional_val().ok_or_else(|| eyre!("failed to get value")).unwrap();
 //! ```
 //!
 //! #### `Context` and `Option`
@@ -250,10 +256,10 @@
 //! With `eyre` we want users to write:
 //!
 //! ```rust
-//! use eyre::eyre;
+//! use eyre::{eyre, Result};
 //!
 //! let opt: Option<()> = None;
-//! let result = opt.ok_or_else(|| eyre!("new error message"));
+//! let result: Result<()> = opt.ok_or_else(|| eyre!("new error message"));
 //! ```
 //!
 //! However, to help with porting we do provide a `ContextCompat` trait which
@@ -930,7 +936,7 @@ where
 #[doc(hidden)]
 pub mod private {
     use crate::{EyreContext, Report};
-    use core::fmt::Display;
+    use core::fmt::{Debug, Display};
 
     //     #[cfg(backtrace)]
     //     use std::backtrace::Backtrace;
@@ -948,7 +954,7 @@ pub mod private {
     pub fn new_adhoc<M, C>(message: M) -> Report<C>
     where
         C: EyreContext,
-        M: Display + Send + Sync + 'static,
+        M: Display + Debug + Send + Sync + 'static,
     {
         Report::from_adhoc(message)
     }

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -2,36 +2,18 @@ use crate::StdError;
 use core::fmt::{self, Debug, Display};
 
 #[repr(transparent)]
-pub struct MessageError<M>(pub M);
-
-impl<M> Debug for MessageError<M>
-where
-    M: Display + Debug,
-{
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        Debug::fmt(&self.0, f)
-    }
-}
-
-impl<M> Display for MessageError<M>
-where
-    M: Display + Debug,
-{
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        Display::fmt(&self.0, f)
-    }
-}
-
-impl<M> StdError for MessageError<M> where M: Display + Debug + 'static {}
+pub(crate) struct DisplayError<M>(pub(crate) M);
 
 #[repr(transparent)]
-pub struct DisplayError<M>(pub M);
+pub(crate) struct MessageError<M>(pub(crate) M);
+
+pub(crate) struct NoneError;
 
 impl<M> Debug for DisplayError<M>
 where
     M: Display,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         Display::fmt(&self.0, f)
     }
 }
@@ -40,27 +22,61 @@ impl<M> Display for DisplayError<M>
 where
     M: Display,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         Display::fmt(&self.0, f)
     }
 }
 
 impl<M> StdError for DisplayError<M> where M: Display + 'static {}
 
+impl<M> Debug for MessageError<M>
+where
+    M: Display + Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Debug::fmt(&self.0, f)
+    }
+}
+
+impl<M> Display for MessageError<M>
+where
+    M: Display + Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Display::fmt(&self.0, f)
+    }
+}
+
+impl<M> StdError for MessageError<M> where M: Display + Debug + 'static {}
+
+impl Debug for NoneError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Debug::fmt("Option was None", f)
+    }
+}
+
+impl Display for NoneError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Display::fmt("Option was None", f)
+    }
+}
+
+impl StdError for NoneError {}
+
 #[cfg(feature = "std")]
 #[repr(transparent)]
-pub struct BoxedError(pub Box<dyn StdError + Send + Sync>);
+pub(crate) struct BoxedError(pub(crate) Box<dyn StdError + Send + Sync>);
 
 #[cfg(feature = "std")]
 impl Debug for BoxedError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         Debug::fmt(&self.0, f)
     }
 }
 
 #[cfg(feature = "std")]
 impl Display for BoxedError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         Display::fmt(&self.0, f)
     }
 }


### PR DESCRIPTION
Turns out there was one more thing I broke from anyhow, we dont impl `WrapErr` on `Option`. 