### PR TITLE
Fixed use of std::fmt rather than core::fmt

### DIFF
--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -10,13 +10,13 @@ where
         self.context
             .as_ref()
             .map(|context| context.display(self.error(), f))
-            .unwrap_or_else(|| std::fmt::Display::fmt(self.error(), f))
+            .unwrap_or_else(|| core::fmt::Display::fmt(self.error(), f))
     }
 
     pub(crate) fn debug(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.context
             .as_ref()
             .map(|context| context.debug(self.error(), f))
-            .unwrap_or_else(|| std::fmt::Debug::fmt(self.error(), f))
+            .unwrap_or_else(|| core::fmt::Debug::fmt(self.error(), f))
     }
 }


### PR DESCRIPTION
`no_std` seems to be broken because `src/fmt.rs` uses `std` rather than `core` for  `Debug` and `Display` traits. Changed to use `core` which has fixed it for me, all tests still passing.