### PR TITLE
[WIP] fix #20 improve test support for `no_std`

### DIFF
--- a/src/chain.rs
+++ b/src/chain.rs
@@ -4,13 +4,7 @@ use crate::StdError;
 #[cfg(feature = "std")]
 use std::vec;
 
-#[cfg(feature = "std")]
 pub(crate) use crate::Chain;
-
-#[cfg(not(feature = "std"))]
-pub(crate) struct Chain<'a> {
-    state: ChainState<'a>,
-}
 
 #[derive(Clone)]
 pub(crate) enum ChainState<'a> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,5 @@
 use crate::alloc::Box;
+#[cfg(feature = "std")]
 use crate::chain::Chain;
 use crate::EyreContext;
 use crate::{Report, StdError};
@@ -729,6 +730,7 @@ where
         unsafe { &mut *(self.vtable.object_mut)(self) }
     }
 
+    #[cfg(feature = "std")]
     pub(crate) fn chain(&self) -> Chain<'_> {
         Chain::new(self.error())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -342,8 +342,8 @@ mod alloc {
     #[cfg(feature = "std")]
     pub(crate) use std::boxed::Box;
 
-    #[cfg(not(feature = "std"))]
-    pub(crate) use alloc::string::String;
+    // #[cfg(not(feature = "std"))]
+    // pub(crate) use alloc::string::String;
 
     // #[cfg(feature = "std")]
     // pub(crate) use std::string::String;
@@ -371,8 +371,11 @@ use core::fmt::Debug;
 #[cfg(feature = "std")]
 use std::error::Error as StdError;
 
+/// `StdError` is a trait representing expectations for error values for no_std mode where the
+/// `std::error::Error` trait is not available.
 #[cfg(not(feature = "std"))]
 pub trait StdError: Debug + Display {
+    /// The lower-level source of this error, if any.
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
         None
     }
@@ -778,8 +781,7 @@ impl EyreContext for DefaultContext {
 ///     None
 /// }
 /// ```
-#[cfg(feature = "std")]
-#[derive(Clone)]
+#[cfg_attr(feature = "std", derive(Clone))]
 #[allow(missing_debug_implementations)]
 pub struct Chain<'a> {
     state: crate::chain::ChainState<'a>,


### PR DESCRIPTION
This PR is part of the work to fix broken tests in `no_std`. (#20)

So far ea5a0884e5f4a1c8febd5d401ec4fd7c19e2548d includes changes to make eyre compile successfully when `--no-default-feature` is used.
Changes made:
* replaced `std::fmt::Display` with `score::fmt::Display`
* unified the two `Chain` structs into single `Chain` both for `std` and `no_std`. This was necessary because the `crate::chain::Chain` was only `pub(crate)` for `no_std`.
* added some docs and removed unused to make clippy happy.

To fix all the tests for `no_std` is a lot more work, since all the tests using `io::Error` won't work. 
To add test support `no_std`, I could start with replacing the `io::Error` dependent variants in the `TestError` with something that supports `no_std`? This could minimize test duplication for `no_std`
 
Before I proceed I'd like to get some feedback and I'm happy to hear suggestions.

