### PR TITLE
Support format arguments capture

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,6 +2,7 @@ use std::env;
 use std::fs;
 use std::path::Path;
 use std::process::{Command, ExitStatus};
+use std::str;
 
 // This code exercises the surface area that we expect of the std Backtrace
 // type. If the current toolchain is able to compile it, we go ahead and use
@@ -53,6 +54,15 @@ fn main() {
         Some(status) if status.success() => println!("cargo:rustc-cfg=track_caller"),
         _ => {}
     }
+
+    let rustc = match rustc_minor_version() {
+        Some(rustc) => rustc,
+        None => return,
+    };
+
+    if rustc < 52 {
+        println!("cargo:rustc-cfg=eyre_no_fmt_arguments_as_str");
+    }
 }
 
 fn compile_probe(probe: &str) -> Option<ExitStatus> {
@@ -70,4 +80,15 @@ fn compile_probe(probe: &str) -> Option<ExitStatus> {
         .arg(probefile)
         .status()
         .ok()
+}
+
+fn rustc_minor_version() -> Option<u32> {
+    let rustc = env::var_os("RUSTC")?;
+    let output = Command::new(rustc).arg("--version").output().ok()?;
+    let version = str::from_utf8(&output.stdout).ok()?;
+    let mut pieces = version.split('.');
+    if pieces.next() != Some("rustc 1") {
+        return None;
+    }
+    pieces.next()?.parse().ok()
 }

--- a/build.rs
+++ b/build.rs
@@ -63,6 +63,10 @@ fn main() {
     if rustc < 52 {
         println!("cargo:rustc-cfg=eyre_no_fmt_arguments_as_str");
     }
+
+    if rustc < 58 {
+        println!("cargo:rustc-cfg=eyre_no_fmt_args_capture");
+    }
 }
 
 fn compile_probe(probe: &str) -> Option<ExitStatus> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1141,9 +1141,9 @@ pub mod private {
     #[doc(hidden)]
     #[cold]
     pub fn format_err(args: Arguments<'_>) -> Report {
-        #[cfg(anyhow_no_fmt_arguments_as_str)]
+        #[cfg(eyre_no_fmt_arguments_as_str)]
         let fmt_arguments_as_str: Option<&str> = None;
-        #[cfg(not(anyhow_no_fmt_arguments_as_str))]
+        #[cfg(not(eyre_no_fmt_arguments_as_str))]
         let fmt_arguments_as_str = args.as_str();
 
         if let Some(message) = fmt_arguments_as_str {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -148,17 +148,18 @@ macro_rules! ensure {
 /// ```
 #[macro_export]
 macro_rules! eyre {
-    ($msg:literal $(,)?) => {
-        // Handle $:literal as a special case to make cargo-expanded code more
-        // concise in the common case.
-        $crate::private::new_adhoc($msg)
-    };
+    ($msg:literal $(,)?) => ({
+        let error = $crate::private::format_err($crate::private::format_args!($msg));
+        error
+    });
     ($err:expr $(,)?) => ({
         use $crate::private::kind::*;
-        let error = $err;
-        (&error).eyre_kind().new(error)
+        let error = match $err {
+            error => (&error).eyre_kind().new(error),
+        };
+        error
     });
     ($fmt:expr, $($arg:tt)*) => {
-        $crate::private::new_adhoc(format!($fmt, $($arg)*))
+        $crate::private::new_adhoc($crate::private::format!($fmt, $($arg)*))
     };
 }

--- a/tests/test_chain.rs
+++ b/tests/test_chain.rs
@@ -1,7 +1,7 @@
 use eyre::{eyre, Report};
 
 fn error() -> Report {
-    eyre!(0).wrap_err(1).wrap_err(2).wrap_err(3)
+    eyre!({ 0 }).wrap_err(1).wrap_err(2).wrap_err(3)
 }
 
 #[test]

--- a/tests/test_downcast.rs
+++ b/tests/test_downcast.rs
@@ -10,10 +10,18 @@ use std::io;
 
 #[test]
 fn test_downcast() {
+    #[cfg(not(eyre_no_fmt_arguments_as_str))]
     assert_eq!(
         "oh no!",
         bail_literal().unwrap_err().downcast::<&str>().unwrap(),
     );
+
+    #[cfg(eyre_no_fmt_arguments_as_str)]
+    assert_eq!(
+        "oh no!",
+        bail_literal().unwrap_err().downcast::<String>().unwrap(),
+    );
+
     assert_eq!(
         "oh no!",
         bail_fmt().unwrap_err().downcast::<String>().unwrap(),
@@ -30,10 +38,21 @@ fn test_downcast() {
 
 #[test]
 fn test_downcast_ref() {
+    #[cfg(not(eyre_no_fmt_arguments_as_str))]
     assert_eq!(
         "oh no!",
         *bail_literal().unwrap_err().downcast_ref::<&str>().unwrap(),
     );
+
+    #[cfg(eyre_no_fmt_arguments_as_str)]
+    assert_eq!(
+        "oh no!",
+        *bail_literal()
+            .unwrap_err()
+            .downcast_ref::<String>()
+            .unwrap(),
+    );
+
     assert_eq!(
         "oh no!",
         bail_fmt().unwrap_err().downcast_ref::<String>().unwrap(),
@@ -50,10 +69,21 @@ fn test_downcast_ref() {
 
 #[test]
 fn test_downcast_mut() {
+    #[cfg(not(eyre_no_fmt_arguments_as_str))]
     assert_eq!(
         "oh no!",
         *bail_literal().unwrap_err().downcast_mut::<&str>().unwrap(),
     );
+
+    #[cfg(eyre_no_fmt_arguments_as_str)]
+    assert_eq!(
+        "oh no!",
+        *bail_literal()
+            .unwrap_err()
+            .downcast_mut::<String>()
+            .unwrap(),
+    );
+
     assert_eq!(
         "oh no!",
         bail_fmt().unwrap_err().downcast_mut::<String>().unwrap(),

--- a/tests/test_macros.rs
+++ b/tests/test_macros.rs
@@ -2,7 +2,9 @@
 mod common;
 
 use self::common::*;
-use eyre::{ensure, Result};
+use eyre::{ensure, eyre, Result};
+use std::cell::Cell;
+use std::future;
 
 #[test]
 fn test_messages() {
@@ -31,4 +33,38 @@ fn test_ensure() {
         Ok(())
     };
     assert!(f().is_err());
+}
+
+#[test]
+fn test_temporaries() {
+    fn require_send_sync(_: impl Send + Sync) {}
+
+    require_send_sync(async {
+        // If eyre hasn't dropped any temporary format_args it creates by the
+        // time it's done evaluating, those will stick around until the
+        // semicolon, which is on the other side of the await point, making the
+        // enclosing future non-Send.
+        future::ready(eyre!("...")).await;
+    });
+
+    fn message(cell: Cell<&str>) -> &str {
+        cell.get()
+    }
+
+    require_send_sync(async {
+        future::ready(eyre!(message(Cell::new("...")))).await;
+    });
+}
+
+#[test]
+fn test_capture_format_args() {
+    let var = 42;
+    let err = eyre!("interpolate {var}");
+    assert_eq!("interpolate 42", err.to_string());
+}
+
+#[test]
+fn test_brace_escape() {
+    let err = eyre!("unterminated ${{..}} expression");
+    assert_eq!("unterminated ${..} expression", err.to_string());
 }


### PR DESCRIPTION
Closes #64.

Based on dtolnay/anyhow#180, dtolnay/anyhow#184 and dtolnay/anyhow#185, with the fixes from dtolnay/anyhow#183 and dtolnay/anyhow#187.

Note: like for `anyhow 1.0.46`, this is potentially a breaking change: the macro `eyre!` no more accepts a literal parameter other than a string literal as the first parameter. The workaround is to wrap the parameter with parentheses or curly braces.