### PR TITLE
Add #[track_caller] to `format_err`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1153,6 +1153,7 @@ pub mod private {
 
     #[doc(hidden)]
     #[cold]
+    #[cfg_attr(track_caller, track_caller)]
     pub fn format_err(args: Arguments<'_>) -> Report {
         #[cfg(eyre_no_fmt_arguments_as_str)]
         let fmt_arguments_as_str: Option<&str> = None;


### PR DESCRIPTION
`eyre` isn't reporting error locations correctly right now. (😢 )

Example source:

```rust
fn main() -> color_eyre::Result<()> {
    color_eyre::install()?;
    
    Err(eyre::eyre!("Whoops"))
}
```

Released version:

```bash
ana@autonoma:~/git/eyre-demo$ cargo run
    Finished dev [unoptimized + debuginfo] target(s) in 1.74s
     Running `target/debug/eyre-demo`
Error: 
   0: Whoops

Location:
   /home/ana/.cargo/registry/src/github.com-1ecc6299db9ec823/eyre-0.6.6/src/lib.rs:1164

Backtrace omitted.
Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.
```

After this patch it is resolved:

```bash
ana@autonoma:~/git/eyre-demo$ cargo run
    Finished dev [unoptimized + debuginfo] target(s) in 0.01s
     Running `target/debug/eyre-demo`
Error: 
   0: Whoops

Location:
   src/main.rs:4

Backtrace omitted.
Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.
```