### PR TITLE
Mark `Report` as `#[must_use]`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -441,6 +441,7 @@ pub use WrapErr as Context;
 ///
 /// [`EyreHandler`]: trait.EyreHandler.html
 /// [`hook`]: fn.set_hook.html
+#[must_use]
 pub struct Report {
     inner: ManuallyDrop<Box<ErrorImpl<()>>>,
 }


### PR DESCRIPTION
Not using the error type after construction is a common mistake. This can also easily happen with the provided macros, when using `eyre!` instead of `eyre::bail!`. By marking the type as `#[must_use]`, the compiler warns us in such cases.
