### PR TITLE
Run `miri` on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,7 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
           override: true
+          component: miri
       - uses: actions-rs/cargo@v1
         with:
           command: miri

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,26 @@ jobs:
           command: test
           args: ${{ matrix.features }}
 
+  miri:
+    name: Miri
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - nightly
+        features:
+          - --all-features
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: miri
+          args: test ${{ matrix.features }}
+
   test-msrv:
     name: Test Suite
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
           override: true
-          component: miri
+          components: miri
       - uses: actions-rs/cargo@v1
         with:
           command: miri

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -1,4 +1,5 @@
 #[rustversion::attr(not(nightly), ignore)]
+#[cfg_attr(miri, ignore)]
 #[test]
 fn ui() {
     let t = trybuild::TestCases::new();

--- a/tests/test_location.rs
+++ b/tests/test_location.rs
@@ -39,6 +39,7 @@ impl eyre::EyreHandler for LocationHandler {
     }
 }
 
+#[cfg_attr(miri, ignore)]
 #[test]
 fn test_wrap_err() {
     let _ = eyre::set_hook(Box::new(|_e| {
@@ -54,6 +55,7 @@ fn test_wrap_err() {
     println!("{:?}", err);
 }
 
+#[cfg_attr(miri, ignore)]
 #[test]
 fn test_wrap_err_with() {
     let _ = eyre::set_hook(Box::new(|_e| {
@@ -69,6 +71,7 @@ fn test_wrap_err_with() {
     println!("{:?}", err);
 }
 
+#[cfg_attr(miri, ignore)]
 #[test]
 fn test_context() {
     let _ = eyre::set_hook(Box::new(|_e| {
@@ -84,6 +87,7 @@ fn test_context() {
     println!("{:?}", err);
 }
 
+#[cfg_attr(miri, ignore)]
 #[test]
 fn test_with_context() {
     let _ = eyre::set_hook(Box::new(|_e| {

--- a/tests/test_pyo3.rs
+++ b/tests/test_pyo3.rs
@@ -17,6 +17,7 @@ fn h() -> Result<()> {
     g().wrap_err("g failed")
 }
 
+#[cfg_attr(miri, ignore)]
 #[test]
 fn test_pyo3_exception_contents() {
     use pyo3::types::IntoPyDict;


### PR DESCRIPTION
As mentioned in #81 here is a small PR disabling the tests, which are not compatible with `miri`. Also, I found a few other `mem::transmute`s. The job will run in the CI, you might want to mark it as required 🙂 