### PR TITLE
typo-fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This library provides [`eyre::Report`][Report], a trait object based
 error handling type for easy idiomatic error handling and reporting in Rust
 applications.
 
-This crate is a fork of [`anyhow`]  with a support for customized
+This crate is a fork of [`anyhow`]  with support for customized
 error reports. For more details on customization checkout the docs on
 [`eyre::EyreHandler`].
 


### PR DESCRIPTION
Fixed a typo in the README. An _a_ was left in the sentence, probably when the sentence was rewritten.