### PR TITLE
unfuck CI (update syn/thiserror)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,11 @@ track-caller = []
 [dev-dependencies]
 futures = { version = "0.3", default-features = false }
 rustversion = "1.0"
-thiserror = "1.0"
+thiserror = "1.0.40"
 trybuild = { version = "1.0.19", features = ["diff"] }
 backtrace = "0.3.46"
 anyhow = "1.0.28"
-syn = { version = "1.0", features = ["full"] }
+syn = { version = "2.0", features = ["full"] }
 pyo3 = { version = "0.13", default-features = false, features = ["auto-initialize"] }
 
 [dependencies]


### PR DESCRIPTION
There's a rocky transition point here around thiserror 1.0.40 and syn2 that depends on precise build-specific dependency-resolution to go awry. Pushing both over the edge in lockstep I think avoids the mess deterministically (although 0.2.11(?) had a bug fix it might be worth forcing too..).