### PR TITLE
Fix miri validation errors through now stricter provenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           command: check
 
   test-matrix:
-    name: Test Suite Matrix
+    name: Test Suite
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -55,7 +55,7 @@ jobs:
           args: ${{ matrix.features }}
 
   test-msrv:
-    name: Test MSRV
+    name: Test Suite
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -76,7 +76,7 @@ jobs:
           command: test
 
   test-os:
-    name: Test Platform Matrix
+    name: Test Suite
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
 
 name: Continuous integration
 
+env:
+  MIRIFLAGS: -Zmiri-strict-provenance
+
 jobs:
   check:
     name: Check
@@ -126,3 +129,17 @@ jobs:
         with:
           command: clippy
           args: -- -D warnings
+  miri:
+    name: Miri
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          components: miri
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: miri
+          args: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.60
+          toolchain: 1.65
           override: true
       - uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.42
+          toolchain: 1.60
           override: true
       - uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           command: check
 
   test-matrix:
-    name: Test Suite
+    name: Test Suite Matrix
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -55,7 +55,7 @@ jobs:
           args: ${{ matrix.features }}
 
   test-msrv:
-    name: Test Suite
+    name: Test MSRV
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -76,7 +76,7 @@ jobs:
           command: test
 
   test-os:
-    name: Test Suite
+    name: Test Platform Matrix
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ pyo3 = { version = "0.13", default-features = false, features = ["auto-initializ
 
 [dependencies]
 indenter = "0.3.0"
-once_cell = "1.4.0"
+once_cell = "1.18.0"
 pyo3 = { version = "0.13", optional = true, default-features = false }
 
 [package.metadata.docs.rs]

--- a/src/context.rs
+++ b/src/context.rs
@@ -158,7 +158,7 @@ where
     D: Display,
 {
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
-        Some(ErrorImpl::error(self.error.inner.as_ptr()))
+        Some(ErrorImpl::error(self.error.inner.as_ref()))
     }
 }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,4 +1,4 @@
-use crate::error::ContextError;
+use crate::error::{ContextError, ErrorImpl};
 use crate::{ContextCompat, Report, StdError, WrapErr};
 use core::fmt::{self, Debug, Display, Write};
 
@@ -158,7 +158,7 @@ where
     D: Display,
 {
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
-        Some(self.error.inner.error())
+        Some(ErrorImpl::error(self.error.inner.as_ptr()))
     }
 }
 

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -3,7 +3,7 @@ use core::fmt;
 
 impl ErrorImpl<()> {
     pub(crate) fn display(this: RefPtr<'_, Self>, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        unsafe { this.as_ref() }
+        ErrorImpl::header(this)
             .handler
             .as_ref()
             .map(|handler| handler.display(Self::error(this), f))
@@ -12,7 +12,7 @@ impl ErrorImpl<()> {
 
     /// Debug formats the error using the captured handler
     pub(crate) fn debug(this: RefPtr<'_, Self>, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        unsafe { this.as_ref() }
+        ErrorImpl::header(this)
             .handler
             .as_ref()
             .map(|handler| handler.debug(Self::error(this), f))

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -1,18 +1,21 @@
-use crate::error::ErrorImpl;
+use crate::{error::ErrorImpl, ptr::RefPtr};
 use core::fmt;
 
 impl ErrorImpl<()> {
-    pub(crate) fn display(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.handler
+    pub(crate) fn display(this: RefPtr<'_, Self>, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        unsafe { this.as_ref() }
+            .handler
             .as_ref()
-            .map(|handler| handler.display(self.error(), f))
-            .unwrap_or_else(|| core::fmt::Display::fmt(self.error(), f))
+            .map(|handler| handler.display(Self::error(this), f))
+            .unwrap_or_else(|| core::fmt::Display::fmt(Self::error(this), f))
     }
 
-    pub(crate) fn debug(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.handler
+    /// Debug formats the error using the captured handler
+    pub(crate) fn debug(this: RefPtr<'_, Self>, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        unsafe { this.as_ref() }
+            .handler
             .as_ref()
-            .map(|handler| handler.debug(self.error(), f))
-            .unwrap_or_else(|| core::fmt::Debug::fmt(self.error(), f))
+            .map(|handler| handler.debug(Self::error(this), f))
+            .unwrap_or_else(|| core::fmt::Debug::fmt(Self::error(this), f))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -370,6 +370,7 @@ mod error;
 mod fmt;
 mod kind;
 mod macros;
+mod ptr;
 mod wrapper;
 
 use crate::backtrace::Backtrace;
@@ -383,6 +384,7 @@ pub use eyre as format_err;
 /// Compatibility re-export of `eyre` for interop with `anyhow`
 pub use eyre as anyhow;
 use once_cell::sync::OnceCell;
+use ptr::OwnedPtr;
 #[doc(hidden)]
 pub use DefaultHandler as DefaultContext;
 #[doc(hidden)]
@@ -469,7 +471,7 @@ pub use WrapErr as Context;
 /// [`hook`]: fn.set_hook.html
 #[must_use]
 pub struct Report {
-    inner: ManuallyDrop<Box<ErrorImpl<()>>>,
+    inner: OwnedPtr<ErrorImpl<()>>,
 }
 
 type ErrorHook =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -376,7 +376,6 @@ mod wrapper;
 use crate::backtrace::Backtrace;
 use crate::error::ErrorImpl;
 use core::fmt::Display;
-use core::mem::ManuallyDrop;
 
 use std::error::Error as StdError;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -334,6 +334,7 @@
     missing_docs,
     // FIXME: this lint is currently nightly only
     rustdoc::missing_doc_code_examples,
+    unsafe_op_in_unsafe_fn,
     rust_2018_idioms,
     unreachable_pub,
     bad_style,

--- a/src/ptr.rs
+++ b/src/ptr.rs
@@ -45,7 +45,7 @@ impl<T> OwnedPtr<T> {
     ///
     /// A cast pointer must therefore be cast back to the original type before calling this method.
     pub(crate) unsafe fn into_box(self) -> Box<T> {
-        Box::from_raw(self.ptr.as_ptr())
+        unsafe { Box::from_raw(self.ptr.as_ptr()) }
     }
 
     pub(crate) const fn as_ref(&self) -> RefPtr<'_, T> {
@@ -105,7 +105,7 @@ impl<'a, T: ?Sized> RefPtr<'a, T> {
     /// See: [`NonNull::as_ref`]
     #[inline]
     pub(crate) unsafe fn as_ref(&self) -> &'a T {
-        self.ptr.as_ref()
+        unsafe { self.ptr.as_ref() }
     }
 }
 
@@ -144,6 +144,6 @@ impl<'a, T: ?Sized> MutPtr<'a, T> {
     /// See: [`NonNull::as_mut`]
     #[inline]
     pub(crate) unsafe fn into_mut(mut self) -> &'a mut T {
-        self.ptr.as_mut()
+        unsafe { self.ptr.as_mut() }
     }
 }

--- a/src/ptr.rs
+++ b/src/ptr.rs
@@ -1,0 +1,196 @@
+use std::{marker::PhantomData, ptr::NonNull};
+
+/// An owned pointer
+///
+/// **NOTE**: Does not deallocate when dropped
+pub(crate) struct OwnedPtr<T: ?Sized> {
+    pub(crate) ptr: NonNull<T>,
+}
+
+impl<T: ?Sized> Copy for OwnedPtr<T> {}
+
+impl<T: ?Sized> Clone for OwnedPtr<T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+unsafe impl<T> Send for OwnedPtr<T> where T: Send {}
+unsafe impl<T> Sync for OwnedPtr<T> where T: Send {}
+
+impl<T> OwnedPtr<T> {
+    pub(crate) fn new(value: T) -> Self {
+        Self::from_boxed(Box::new(value))
+    }
+
+    pub(crate) fn from_boxed(boxed: Box<T>) -> Self {
+        // Safety: `Box::into_raw` is guaranteed to be non-null
+        Self {
+            ptr: unsafe { NonNull::new_unchecked(Box::into_raw(boxed)) },
+        }
+    }
+
+    /// Convert the pointer to another type
+    pub(crate) fn cast<U>(self) -> OwnedPtr<U> {
+        OwnedPtr {
+            ptr: self.ptr.cast(),
+        }
+    }
+
+    /// Context the pointer into a Box
+    ///
+    /// # Safety
+    ///
+    /// Dropping the Box will deallocate a layout of `T` and run the destructor of `T`.
+    ///
+    /// A cast pointer must therefore be cast back to the original type before calling this method.
+    pub(crate) unsafe fn into_box(self) -> Box<T> {
+        Box::from_raw(self.ptr.as_ptr())
+    }
+
+    /// Returns a shared reference to the owned value
+    ///
+    /// # Safety
+    ///
+    /// See: [`NonNull::as_ref`]
+    #[inline]
+    pub(crate) const unsafe fn as_ref(&self) -> &T {
+        self.ptr.as_ref()
+    }
+
+    /// Returns a mutable reference to the owned value
+    ///
+    /// # Safety
+    ///
+    /// See: [`NonNull::as_mut`]
+    #[inline]
+    pub(crate) unsafe fn as_mut(&mut self) -> &mut T {
+        self.ptr.as_mut()
+    }
+
+    pub(crate) const fn as_ptr<'a>(&'a self) -> RefPtr<'a, T> {
+        RefPtr {
+            ptr: self.ptr,
+            _marker: PhantomData,
+        }
+    }
+
+    pub(crate) fn as_mut_ptr<'a>(&'a self) -> MutPtr<'a, T> {
+        MutPtr {
+            ptr: self.ptr,
+            _marker: PhantomData,
+        }
+    }
+}
+
+/// Convenience lifetime annotated mutable pointer which facilitates returning an inferred lifetime
+/// in a `fn` pointer.
+pub(crate) struct RefPtr<'a, T: ?Sized> {
+    pub(crate) ptr: NonNull<T>,
+    _marker: PhantomData<&'a T>,
+}
+
+/// Safety: RefPtr indicates a shared reference to a value and as such exhibits the same Send +
+/// Sync behavior of &'a T
+unsafe impl<'a, T: ?Sized> Send for RefPtr<'a, T> where &'a T: Send {}
+unsafe impl<'a, T: ?Sized> Sync for RefPtr<'a, T> where &'a T: Sync {}
+
+impl<'a, T: ?Sized> Copy for RefPtr<'a, T> {}
+impl<'a, T: ?Sized> Clone for RefPtr<'a, T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<'a, T: ?Sized> RefPtr<'a, T> {
+    pub(crate) fn new(ptr: &'a T) -> Self {
+        Self {
+            ptr: NonNull::from(ptr),
+            _marker: PhantomData,
+        }
+    }
+
+    /// Convert the pointer to another type
+    pub(crate) fn cast<U>(self) -> RefPtr<'a, U> {
+        RefPtr {
+            ptr: self.ptr.cast(),
+            _marker: PhantomData,
+        }
+    }
+
+    /// Returns a shared reference to the owned value
+    ///
+    /// # Safety
+    ///
+    /// See: [`NonNull::as_ref`]
+    #[inline]
+    pub(crate) unsafe fn as_ref(&self) -> &'a T {
+        self.ptr.as_ref()
+    }
+}
+
+/// Convenience lifetime annotated mutable pointer which facilitates returning an inferred lifetime
+/// in a `fn` pointer.
+pub(crate) struct MutPtr<'a, T: ?Sized> {
+    pub(crate) ptr: NonNull<T>,
+    _marker: PhantomData<&'a mut T>,
+}
+
+/// Safety: RefPtr indicates an exclusive reference to a value and as such exhibits the same Send +
+/// Sync behavior of &'a mut T
+unsafe impl<'a, T: ?Sized> Send for MutPtr<'a, T> where &'a mut T: Send {}
+unsafe impl<'a, T: ?Sized> Sync for MutPtr<'a, T> where &'a mut T: Sync {}
+
+impl<'a, T: ?Sized> Copy for MutPtr<'a, T> {}
+impl<'a, T: ?Sized> Clone for MutPtr<'a, T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<'a, T: ?Sized> MutPtr<'a, T> {
+    pub(crate) fn new(ptr: &'a mut T) -> Self {
+        Self {
+            ptr: NonNull::from(ptr),
+            _marker: PhantomData,
+        }
+    }
+
+    /// Convert the pointer to another type
+    pub(crate) fn cast<U>(self) -> MutPtr<'a, U> {
+        MutPtr {
+            ptr: self.ptr.cast(),
+            _marker: PhantomData,
+        }
+    }
+
+    /// Returns a shared reference to the owned value
+    ///
+    /// # Safety
+    ///
+    /// See: [`NonNull::as_ref`]
+    #[inline]
+    pub(crate) unsafe fn as_ref(&self) -> &'a T {
+        self.ptr.as_ref()
+    }
+
+    /// Returns a mutable reference to the owned value
+    ///
+    /// # Safety
+    ///
+    /// See: [`NonNull::as_mut`]
+    #[inline]
+    pub(crate) unsafe fn as_mut(&'a mut self) -> &'a mut T {
+        self.ptr.as_mut()
+    }
+
+    /// Returns a mutable reference to the owned value with the lifetime decoupled from self
+    ///
+    /// # Safety
+    ///
+    /// See: [`NonNull::as_mut`]
+    #[inline]
+    pub(crate) unsafe fn into_mut(mut self) -> &'a mut T {
+        self.ptr.as_mut()
+    }
+}

--- a/src/ptr.rs
+++ b/src/ptr.rs
@@ -68,14 +68,14 @@ impl<T> OwnedPtr<T> {
         self.ptr.as_mut()
     }
 
-    pub(crate) const fn as_ptr<'a>(&'a self) -> RefPtr<'a, T> {
+    pub(crate) const fn as_ptr(&self) -> RefPtr<'_, T> {
         RefPtr {
             ptr: self.ptr,
             _marker: PhantomData,
         }
     }
 
-    pub(crate) fn as_mut_ptr<'a>(&'a self) -> MutPtr<'a, T> {
+    pub(crate) fn as_mut_ptr(&mut self) -> MutPtr<'_, T> {
         MutPtr {
             ptr: self.ptr,
             _marker: PhantomData,

--- a/src/ptr.rs
+++ b/src/ptr.rs
@@ -4,7 +4,7 @@ use std::{marker::PhantomData, ptr::NonNull};
 ///
 /// **NOTE**: Does not deallocate when dropped
 pub(crate) struct OwnedPtr<T: ?Sized> {
-    pub(crate) ptr: NonNull<T>,
+    ptr: NonNull<T>,
 }
 
 impl<T: ?Sized> Copy for OwnedPtr<T> {}
@@ -48,34 +48,14 @@ impl<T> OwnedPtr<T> {
         Box::from_raw(self.ptr.as_ptr())
     }
 
-    /// Returns a shared reference to the owned value
-    ///
-    /// # Safety
-    ///
-    /// See: [`NonNull::as_ref`]
-    #[inline]
-    pub(crate) const unsafe fn as_ref(&self) -> &T {
-        self.ptr.as_ref()
-    }
-
-    /// Returns a mutable reference to the owned value
-    ///
-    /// # Safety
-    ///
-    /// See: [`NonNull::as_mut`]
-    #[inline]
-    pub(crate) unsafe fn as_mut(&mut self) -> &mut T {
-        self.ptr.as_mut()
-    }
-
-    pub(crate) const fn as_ptr(&self) -> RefPtr<'_, T> {
+    pub(crate) const fn as_ref(&self) -> RefPtr<'_, T> {
         RefPtr {
             ptr: self.ptr,
             _marker: PhantomData,
         }
     }
 
-    pub(crate) fn as_mut_ptr(&mut self) -> MutPtr<'_, T> {
+    pub(crate) fn as_mut(&mut self) -> MutPtr<'_, T> {
         MutPtr {
             ptr: self.ptr,
             _marker: PhantomData,
@@ -149,39 +129,12 @@ impl<'a, T: ?Sized> Clone for MutPtr<'a, T> {
 }
 
 impl<'a, T: ?Sized> MutPtr<'a, T> {
-    pub(crate) fn new(ptr: &'a mut T) -> Self {
-        Self {
-            ptr: NonNull::from(ptr),
-            _marker: PhantomData,
-        }
-    }
-
     /// Convert the pointer to another type
     pub(crate) fn cast<U>(self) -> MutPtr<'a, U> {
         MutPtr {
             ptr: self.ptr.cast(),
             _marker: PhantomData,
         }
-    }
-
-    /// Returns a shared reference to the owned value
-    ///
-    /// # Safety
-    ///
-    /// See: [`NonNull::as_ref`]
-    #[inline]
-    pub(crate) unsafe fn as_ref(&self) -> &'a T {
-        self.ptr.as_ref()
-    }
-
-    /// Returns a mutable reference to the owned value
-    ///
-    /// # Safety
-    ///
-    /// See: [`NonNull::as_mut`]
-    #[inline]
-    pub(crate) unsafe fn as_mut(&'a mut self) -> &'a mut T {
-        self.ptr.as_mut()
     }
 
     /// Returns a mutable reference to the owned value with the lifetime decoupled from self

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -5,6 +5,9 @@ use core::fmt::{self, Debug, Display};
 pub(crate) struct DisplayError<M>(pub(crate) M);
 
 #[repr(transparent)]
+/// Wraps a Debug + Display type as an error.
+///
+/// Its Debug and Display impls are the same as the wrapped type.
 pub(crate) struct MessageError<M>(pub(crate) M);
 
 pub(crate) struct NoneError;

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -1,4 +1,5 @@
 #[rustversion::attr(not(nightly), ignore)]
+#[cfg_attr(miri, ignore)]
 #[test]
 fn ui() {
     let t = trybuild::TestCases::new();

--- a/tests/test_location.rs
+++ b/tests/test_location.rs
@@ -60,7 +60,7 @@ fn read_path(path: &str) -> Result<String, std::io::Error> {
 }
 
 #[cfg(miri)]
-fn read_path(path: &str) -> Result<String, std::io::Error> {
+fn read_path(_path: &str) -> Result<String, std::io::Error> {
     // Miri doesn't support reading files, so we just return an error
     Err(std::io::Error::new(
         std::io::ErrorKind::Other,

--- a/tests/test_location.rs
+++ b/tests/test_location.rs
@@ -46,12 +46,26 @@ fn test_wrap_err() {
         Box::new(LocationHandler::new(expected_location))
     }));
 
-    let err = std::fs::read_to_string("totally_fake_path")
+    let err = read_path("totally_fake_path")
         .wrap_err("oopsie")
         .unwrap_err();
 
     // should panic if the location isn't in our crate
     println!("{:?}", err);
+}
+
+#[cfg(not(miri))]
+fn read_path(path: &str) -> Result<String, std::io::Error> {
+    std::fs::read_to_string(path)
+}
+
+#[cfg(miri)]
+fn read_path(path: &str) -> Result<String, std::io::Error> {
+    // Miri doesn't support reading files, so we just return an error
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Other,
+        "Miri doesn't support reading files",
+    ))
 }
 
 #[test]
@@ -61,7 +75,7 @@ fn test_wrap_err_with() {
         Box::new(LocationHandler::new(expected_location))
     }));
 
-    let err = std::fs::read_to_string("totally_fake_path")
+    let err = read_path("totally_fake_path")
         .wrap_err_with(|| "oopsie")
         .unwrap_err();
 
@@ -76,7 +90,7 @@ fn test_context() {
         Box::new(LocationHandler::new(expected_location))
     }));
 
-    let err = std::fs::read_to_string("totally_fake_path")
+    let err = read_path("totally_fake_path")
         .context("oopsie")
         .unwrap_err();
 
@@ -91,7 +105,7 @@ fn test_with_context() {
         Box::new(LocationHandler::new(expected_location))
     }));
 
-    let err = std::fs::read_to_string("totally_fake_path")
+    let err = read_path("totally_fake_path")
         .with_context(|| "oopsie")
         .unwrap_err();
 


### PR DESCRIPTION
Miri has become even stricter with regards to pointer borrowing and stacked borrows, especially with the now default *full-field-retagging*