### PR TITLE
fix: typos in documentation files

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ avoid using `eyre::Report` as your public error type.
     public API as well, and makes changing any of those libraries into an
     undetectable runtime breakage.
 - If many of your errors are constructed from strings you encourage your users
-  to use string comparision for reacting to specific errors which is brittle
+  to use string comparison for reacting to specific errors which is brittle
   and turns updating error messages into a potentially undetectable runtime
   breakage.
 


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `comparision` to `comparison`

Please review the changes and let me know if any additional changes are needed.

