### PR TITLE
fix: incorrect type annotation for tuple return value

### DIFF
--- a/color-eyre/scripts/fix_html_examples.py
+++ b/color-eyre/scripts/fix_html_examples.py
@@ -16,7 +16,7 @@ class LineType(enum.Enum):
     SOURCE = enum.auto()
 
     @classmethod
-    def from_line(cls, line: str) -> (LineType, str):
+    def from_line(cls, line: str) -> tuple[LineType, str]:
         if line.startswith("//!"):
             return (cls.OUTER_DOC, line[len("//!") :])
         elif line.startswith("///"):


### PR DESCRIPTION
Noticed that the type annotation `(LineType, str)` was being used, but in Python, this is interpreted as a regular tuple, not a proper type hint. Switched it to `tuple[LineType, str]` for correctness. 