### PR TITLE
Apply colors only when they are supported

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,6 +37,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6680de5231bd6ee4c6191b8a1325daa282b415391ec9d3a37bd34f2060dc73fa"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -105,6 +155,7 @@ name = "color-eyre"
 version = "0.6.5"
 dependencies = [
  "ansi-parser",
+ "anstream",
  "backtrace",
  "color-spantrace",
  "eyre",
@@ -126,6 +177,7 @@ name = "color-spantrace"
 version = "0.3.0"
 dependencies = [
  "ansi-parser",
+ "anstream",
  "once_cell",
  "owo-colors",
  "tracing",
@@ -133,6 +185,12 @@ dependencies = [
  "tracing-error",
  "tracing-subscriber",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "console_error_panic_hook"
@@ -297,6 +355,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -402,6 +466,15 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2611b99ab098a31bdc8be48b4f1a285ca0ced28bd5b4f23e45efa8c63b09efa5"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "overload"
@@ -818,6 +891,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -954,6 +1033,79 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "yansi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,6 +37,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6680de5231bd6ee4c6191b8a1325daa282b415391ec9d3a37bd34f2060dc73fa"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -105,6 +155,7 @@ name = "color-eyre"
 version = "0.6.5"
 dependencies = [
  "ansi-parser",
+ "anstream",
  "backtrace",
  "color-spantrace",
  "eyre",
@@ -125,12 +176,19 @@ name = "color-spantrace"
 version = "0.3.0"
 dependencies = [
  "ansi-parser",
+ "anstream",
  "owo-colors",
  "tracing",
  "tracing-core",
  "tracing-error",
  "tracing-subscriber",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "console_error_panic_hook"
@@ -293,6 +351,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -389,6 +453,15 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2611b99ab098a31bdc8be48b4f1a285ca0ced28bd5b4f23e45efa8c63b09efa5"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "overload"
@@ -767,6 +840,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -903,6 +982,79 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "yansi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ indenter = "0.3.0"
 once_cell = "1.18.0"
 owo-colors = "4.0"
 autocfg = "1.0"
+anstream = "0.6.15"
 
 [profile.dev.package.backtrace]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ include = ["README.md", "LICENSE-APACHE", "LICENSE-MIT", "build.rs", "Cargo.toml
 indenter = "0.3.0"
 owo-colors = "4.3"
 autocfg = "1.0"
+anstream = "0.6.15"
 
 [profile.dev.package.backtrace]
 opt-level = 3

--- a/color-eyre/Cargo.toml
+++ b/color-eyre/Cargo.toml
@@ -27,6 +27,7 @@ owo-colors = { workspace = true }
 color-spantrace = { version = "0.3", path = "../color-spantrace", optional = true }
 once_cell = { workspace = true }
 url = { version = "2.1.1", optional = true }
+anstream = { workspace = true }
 
 [dev-dependencies]
 tracing-subscriber = { version = "0.3.0", features = ["env-filter"] }

--- a/color-eyre/Cargo.toml
+++ b/color-eyre/Cargo.toml
@@ -26,6 +26,7 @@ indenter = { workspace = true }
 owo-colors = { workspace = true }
 color-spantrace = { version = "0.3", path = "../color-spantrace", optional = true }
 url = { version = "2.1.1", optional = true }
+anstream = { workspace = true }
 
 [dev-dependencies]
 tracing-subscriber = { version = "0.3.0", features = ["env-filter"] }

--- a/color-eyre/examples/theme.rs
+++ b/color-eyre/examples/theme.rs
@@ -1,12 +1,13 @@
-use color_eyre::{config::Theme, eyre::Report, owo_colors::style, Section};
+use color_eyre::{config::Theme, eyre::Report, Section};
+use owo_colors::Style;
 
 /// To experiment with theme values, edit `theme()` below and execute `cargo run --example theme`
 fn theme() -> Theme {
     Theme::dark()
         // ^ use `new` to derive from a blank theme, or `light` to derive from a light theme.
         // Now configure your theme (see the docs for all options):
-        .line_number(style().blue())
-        .help_info_suggestion(style().red())
+        .line_number(Style::new().blue())
+        .help_info_suggestion(Style::new().red())
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/color-eyre/examples/theme.rs
+++ b/color-eyre/examples/theme.rs
@@ -1,12 +1,13 @@
-use color_eyre::{Section, config::Theme, eyre::Report, owo_colors::style};
+use color_eyre::{Section, config::Theme, eyre::Report};
+use owo_colors::Style;
 
 /// To experiment with theme values, edit `theme()` below and execute `cargo run --example theme`
 fn theme() -> Theme {
     Theme::dark()
         // ^ use `new` to derive from a blank theme, or `light` to derive from a light theme.
         // Now configure your theme (see the docs for all options):
-        .line_number(style().blue())
-        .help_info_suggestion(style().red())
+        .line_number(Style::new().blue())
+        .help_info_suggestion(Style::new().red())
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/color-eyre/src/config.rs
+++ b/color-eyre/src/config.rs
@@ -3,7 +3,7 @@
 #![allow(deprecated)] // for PanicHook until we bump MSRV
 use crate::{
     section::PanicMessage,
-    style_if_possible,
+    style,
     writers::{EnvSection, WriterExt},
 };
 use fmt::Display;
@@ -194,12 +194,12 @@ impl fmt::Display for StyledFrame<'_> {
         };
 
         if is_dependency_code {
-            write!(f, "{}", style_if_possible(name, theme.dependency_code))?;
+            write!(f, "{}", style(name, theme.dependency_code))?;
         } else {
-            write!(f, "{}", style_if_possible(name, theme.crate_code))?;
+            write!(f, "{}", style(name, theme.crate_code))?;
         }
 
-        write!(f, "{}", style_if_possible(hash_suffix, theme.code_hash))?;
+        write!(f, "{}", style(hash_suffix, theme.code_hash))?;
 
         let mut separated = f.header("\n");
 
@@ -216,8 +216,8 @@ impl fmt::Display for StyledFrame<'_> {
         write!(
             &mut separated.ready(),
             "    at {}:{}",
-            style_if_possible(file, theme.file),
-            style_if_possible(lineno, theme.line_number),
+            style(file, theme.file),
+            style(lineno, theme.line_number),
         )?;
 
         let v = if std::thread::panicking() {
@@ -268,9 +268,9 @@ impl fmt::Display for SourceSection<'_> {
                 write!(
                     &mut f,
                     "{:>8} {} {}",
-                    style_if_possible(cur_line_no, theme.active_line),
-                    style_if_possible(">", theme.active_line),
-                    style_if_possible(line, theme.active_line),
+                    style(cur_line_no, theme.active_line),
+                    style(">", theme.active_line),
+                    style(line, theme.active_line),
                 )?;
             } else {
                 write!(&mut f, "{cur_line_no:>8} │ {line}")?;
@@ -795,7 +795,7 @@ impl PanicMessage for DefaultPanicMessage {
         writeln!(
             f,
             "{}",
-            style_if_possible("The application panicked (crashed).", theme.panic_header)
+            style("The application panicked (crashed).", theme.panic_header)
         )?;
 
         // Print panic message.
@@ -807,7 +807,7 @@ impl PanicMessage for DefaultPanicMessage {
             .unwrap_or("<non string panic payload>");
 
         write!(f, "Message:  ")?;
-        writeln!(f, "{}", style_if_possible(payload, theme.panic_message))?;
+        writeln!(f, "{}", style(payload, theme.panic_message))?;
 
         // If known, print panic location.
         write!(f, "Location: ")?;
@@ -1127,7 +1127,7 @@ impl fmt::Display for BacktraceFormatter<'_> {
                 write!(
                     &mut separated.ready(),
                     "{:^80}",
-                    style_if_possible(&buf, self.theme.hidden_frames)
+                    style(&buf, self.theme.hidden_frames)
                 )?;
             };
         }

--- a/color-eyre/src/config.rs
+++ b/color-eyre/src/config.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use fmt::Display;
 use indenter::{indented, Format};
-use owo_colors::{style, Style};
+use owo_colors::Style;
 use std::env;
 use std::fmt::Write as _;
 use std::{fmt, path::PathBuf, sync::Arc};
@@ -57,24 +57,24 @@ impl Theme {
     /// Returns a theme for dark backgrounds. This is the default
     pub fn dark() -> Self {
         Self {
-            file: style().purple(),
-            line_number: style().purple(),
-            active_line: style().white().bold(),
-            error: style().bright_red(),
-            help_info_note: style().bright_cyan(),
-            help_info_warning: style().bright_yellow(),
-            help_info_suggestion: style().bright_cyan(),
-            help_info_error: style().bright_red(),
-            dependency_code: style().green(),
-            crate_code: style().bright_red(),
-            code_hash: style().bright_black(),
-            panic_header: style().red(),
-            panic_message: style().cyan(),
-            panic_file: style().purple(),
-            panic_line_number: style().purple(),
-            hidden_frames: style().bright_cyan(),
-            spantrace_target: style().bright_red(),
-            spantrace_fields: style().bright_cyan(),
+            file: Style::new().purple(),
+            line_number: Style::new().purple(),
+            active_line: Style::new().white().bold(),
+            error: Style::new().bright_red(),
+            help_info_note: Style::new().bright_cyan(),
+            help_info_warning: Style::new().bright_yellow(),
+            help_info_suggestion: Style::new().bright_cyan(),
+            help_info_error: Style::new().bright_red(),
+            dependency_code: Style::new().green(),
+            crate_code: Style::new().bright_red(),
+            code_hash: Style::new().bright_black(),
+            panic_header: Style::new().red(),
+            panic_message: Style::new().cyan(),
+            panic_file: Style::new().purple(),
+            panic_line_number: Style::new().purple(),
+            hidden_frames: Style::new().bright_cyan(),
+            spantrace_target: Style::new().bright_red(),
+            spantrace_fields: Style::new().bright_cyan(),
         }
     }
 
@@ -83,24 +83,24 @@ impl Theme {
     /// Returns a theme for light backgrounds
     pub fn light() -> Self {
         Self {
-            file: style().purple(),
-            line_number: style().purple(),
-            spantrace_target: style().red(),
-            spantrace_fields: style().blue(),
-            active_line: style().bold(),
-            error: style().red(),
-            help_info_note: style().blue(),
-            help_info_warning: style().bright_red(),
-            help_info_suggestion: style().blue(),
-            help_info_error: style().red(),
-            dependency_code: style().green(),
-            crate_code: style().red(),
-            code_hash: style().bright_black(),
-            panic_header: style().red(),
-            panic_message: style().blue(),
-            panic_file: style().purple(),
-            panic_line_number: style().purple(),
-            hidden_frames: style().blue(),
+            file: Style::new().purple(),
+            line_number: Style::new().purple(),
+            spantrace_target: Style::new().red(),
+            spantrace_fields: Style::new().blue(),
+            active_line: Style::new().bold(),
+            error: Style::new().red(),
+            help_info_note: Style::new().blue(),
+            help_info_warning: Style::new().bright_red(),
+            help_info_suggestion: Style::new().blue(),
+            help_info_error: Style::new().red(),
+            dependency_code: Style::new().green(),
+            crate_code: Style::new().red(),
+            code_hash: Style::new().bright_black(),
+            panic_header: Style::new().red(),
+            panic_message: Style::new().blue(),
+            panic_file: Style::new().purple(),
+            panic_line_number: Style::new().purple(),
+            hidden_frames: Style::new().blue(),
         }
     }
 

--- a/color-eyre/src/config.rs
+++ b/color-eyre/src/config.rs
@@ -3,11 +3,12 @@
 #![allow(deprecated)] // for PanicHook until we bump MSRV
 use crate::{
     section::PanicMessage,
+    style_if_possible,
     writers::{EnvSection, WriterExt},
 };
 use fmt::Display;
 use indenter::{indented, Format};
-use owo_colors::{style, OwoColorize, Style};
+use owo_colors::{style, Style};
 use std::env;
 use std::fmt::Write as _;
 use std::{fmt, path::PathBuf, sync::Arc};
@@ -193,12 +194,12 @@ impl fmt::Display for StyledFrame<'_> {
         };
 
         if is_dependency_code {
-            write!(f, "{}", (name).style(theme.dependency_code))?;
+            write!(f, "{}", style_if_possible(name, theme.dependency_code))?;
         } else {
-            write!(f, "{}", (name).style(theme.crate_code))?;
+            write!(f, "{}", style_if_possible(name, theme.crate_code))?;
         }
 
-        write!(f, "{}", (hash_suffix).style(theme.code_hash))?;
+        write!(f, "{}", style_if_possible(hash_suffix, theme.code_hash))?;
 
         let mut separated = f.header("\n");
 
@@ -215,8 +216,8 @@ impl fmt::Display for StyledFrame<'_> {
         write!(
             &mut separated.ready(),
             "    at {}:{}",
-            file.style(theme.file),
-            lineno.style(theme.line_number),
+            style_if_possible(file, theme.file),
+            style_if_possible(lineno, theme.line_number),
         )?;
 
         let v = if std::thread::panicking() {
@@ -267,9 +268,9 @@ impl fmt::Display for SourceSection<'_> {
                 write!(
                     &mut f,
                     "{:>8} {} {}",
-                    cur_line_no.style(theme.active_line),
-                    ">".style(theme.active_line),
-                    line.style(theme.active_line),
+                    style_if_possible(cur_line_no, theme.active_line),
+                    style_if_possible(">", theme.active_line),
+                    style_if_possible(line, theme.active_line),
                 )?;
             } else {
                 write!(&mut f, "{cur_line_no:>8} │ {line}")?;
@@ -794,7 +795,7 @@ impl PanicMessage for DefaultPanicMessage {
         writeln!(
             f,
             "{}",
-            "The application panicked (crashed).".style(theme.panic_header)
+            style_if_possible("The application panicked (crashed).", theme.panic_header)
         )?;
 
         // Print panic message.
@@ -806,7 +807,7 @@ impl PanicMessage for DefaultPanicMessage {
             .unwrap_or("<non string panic payload>");
 
         write!(f, "Message:  ")?;
-        writeln!(f, "{}", payload.style(theme.panic_message))?;
+        writeln!(f, "{}", style_if_possible(payload, theme.panic_message))?;
 
         // If known, print panic location.
         write!(f, "Location: ")?;
@@ -1126,7 +1127,7 @@ impl fmt::Display for BacktraceFormatter<'_> {
                 write!(
                     &mut separated.ready(),
                     "{:^80}",
-                    buf.style(self.theme.hidden_frames)
+                    style_if_possible(&buf, self.theme.hidden_frames)
                 )?;
             };
         }

--- a/color-eyre/src/config.rs
+++ b/color-eyre/src/config.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use fmt::Display;
 use indenter::{Format, indented};
-use owo_colors::{Style, style};
+use owo_colors::Style;
 use std::env;
 use std::fmt::Write as _;
 use std::{fmt, path::PathBuf, sync::Arc};
@@ -57,24 +57,24 @@ impl Theme {
     /// Returns a theme for dark backgrounds. This is the default
     pub fn dark() -> Self {
         Self {
-            file: style().purple(),
-            line_number: style().purple(),
-            active_line: style().white().bold(),
-            error: style().bright_red(),
-            help_info_note: style().bright_cyan(),
-            help_info_warning: style().bright_yellow(),
-            help_info_suggestion: style().bright_cyan(),
-            help_info_error: style().bright_red(),
-            dependency_code: style().green(),
-            crate_code: style().bright_red(),
-            code_hash: style().bright_black(),
-            panic_header: style().red(),
-            panic_message: style().cyan(),
-            panic_file: style().purple(),
-            panic_line_number: style().purple(),
-            hidden_frames: style().bright_cyan(),
-            spantrace_target: style().bright_red(),
-            spantrace_fields: style().bright_cyan(),
+            file: Style::new().purple(),
+            line_number: Style::new().purple(),
+            active_line: Style::new().white().bold(),
+            error: Style::new().bright_red(),
+            help_info_note: Style::new().bright_cyan(),
+            help_info_warning: Style::new().bright_yellow(),
+            help_info_suggestion: Style::new().bright_cyan(),
+            help_info_error: Style::new().bright_red(),
+            dependency_code: Style::new().green(),
+            crate_code: Style::new().bright_red(),
+            code_hash: Style::new().bright_black(),
+            panic_header: Style::new().red(),
+            panic_message: Style::new().cyan(),
+            panic_file: Style::new().purple(),
+            panic_line_number: Style::new().purple(),
+            hidden_frames: Style::new().bright_cyan(),
+            spantrace_target: Style::new().bright_red(),
+            spantrace_fields: Style::new().bright_cyan(),
         }
     }
 
@@ -83,24 +83,24 @@ impl Theme {
     /// Returns a theme for light backgrounds
     pub fn light() -> Self {
         Self {
-            file: style().purple(),
-            line_number: style().purple(),
-            spantrace_target: style().red(),
-            spantrace_fields: style().blue(),
-            active_line: style().bold(),
-            error: style().red(),
-            help_info_note: style().blue(),
-            help_info_warning: style().bright_red(),
-            help_info_suggestion: style().blue(),
-            help_info_error: style().red(),
-            dependency_code: style().green(),
-            crate_code: style().red(),
-            code_hash: style().bright_black(),
-            panic_header: style().red(),
-            panic_message: style().blue(),
-            panic_file: style().purple(),
-            panic_line_number: style().purple(),
-            hidden_frames: style().blue(),
+            file: Style::new().purple(),
+            line_number: Style::new().purple(),
+            spantrace_target: Style::new().red(),
+            spantrace_fields: Style::new().blue(),
+            active_line: Style::new().bold(),
+            error: Style::new().red(),
+            help_info_note: Style::new().blue(),
+            help_info_warning: Style::new().bright_red(),
+            help_info_suggestion: Style::new().blue(),
+            help_info_error: Style::new().red(),
+            dependency_code: Style::new().green(),
+            crate_code: Style::new().red(),
+            code_hash: Style::new().bright_black(),
+            panic_header: Style::new().red(),
+            panic_message: Style::new().blue(),
+            panic_file: Style::new().purple(),
+            panic_line_number: Style::new().purple(),
+            hidden_frames: Style::new().blue(),
         }
     }
 

--- a/color-eyre/src/config.rs
+++ b/color-eyre/src/config.rs
@@ -3,11 +3,12 @@
 #![allow(deprecated)] // for PanicHook until we bump MSRV
 use crate::{
     section::PanicMessage,
+    style,
     writers::{EnvSection, WriterExt},
 };
 use fmt::Display;
 use indenter::{Format, indented};
-use owo_colors::{OwoColorize, Style, style};
+use owo_colors::{Style, style};
 use std::env;
 use std::fmt::Write as _;
 use std::{fmt, path::PathBuf, sync::Arc};
@@ -195,12 +196,12 @@ impl fmt::Display for StyledFrame<'_> {
         };
 
         if is_dependency_code {
-            write!(f, "{}", (name).style(theme.dependency_code))?;
+            write!(f, "{}", style(name, theme.dependency_code))?;
         } else {
-            write!(f, "{}", (name).style(theme.crate_code))?;
+            write!(f, "{}", style(name, theme.crate_code))?;
         }
 
-        write!(f, "{}", (hash_suffix).style(theme.code_hash))?;
+        write!(f, "{}", style(hash_suffix, theme.code_hash))?;
 
         let mut separated = f.header("\n");
 
@@ -218,9 +219,9 @@ impl fmt::Display for StyledFrame<'_> {
         write!(
             &mut separated.ready(),
             "    at {}:{}{}",
-            file.style(theme.file),
-            lineno.style(theme.line_number),
-            colno.style(theme.line_number),
+            style(file, theme.file),
+            style(lineno, theme.line_number),
+            style(colno, theme.line_number),
         )?;
 
         let v = if std::thread::panicking() {
@@ -271,9 +272,9 @@ impl fmt::Display for SourceSection<'_> {
                 write!(
                     &mut f,
                     "{:>8} {} {}",
-                    cur_line_no.style(theme.active_line),
-                    ">".style(theme.active_line),
-                    line.style(theme.active_line),
+                    style(cur_line_no, theme.active_line),
+                    style(">", theme.active_line),
+                    style(line, theme.active_line),
                 )?;
             } else {
                 write!(&mut f, "{cur_line_no:>8} │ {line}")?;
@@ -802,7 +803,7 @@ impl PanicMessage for DefaultPanicMessage {
         writeln!(
             f,
             "{}",
-            "The application panicked (crashed).".style(theme.panic_header)
+            style("The application panicked (crashed).", theme.panic_header)
         )?;
 
         // Print panic message.
@@ -814,7 +815,7 @@ impl PanicMessage for DefaultPanicMessage {
             .unwrap_or("<non string panic payload>");
 
         write!(f, "Message:  ")?;
-        writeln!(f, "{}", payload.style(theme.panic_message))?;
+        writeln!(f, "{}", style(payload, theme.panic_message))?;
 
         // If known, print panic location.
         write!(f, "Location: ")?;
@@ -1138,7 +1139,7 @@ impl fmt::Display for BacktraceFormatter<'_> {
                 write!(
                     &mut separated.ready(),
                     "{:^80}",
-                    buf.style(self.theme.hidden_frames)
+                    style(&buf, self.theme.hidden_frames)
                 )?;
             };
         }

--- a/color-eyre/src/fmt.rs
+++ b/color-eyre/src/fmt.rs
@@ -1,6 +1,6 @@
 //! Module for new types that isolate complext formatting
+use crate::style;
 use std::fmt;
-use crate::style_if_possible;
 
 pub(crate) struct LocationSection<'a>(
     pub(crate) Option<&'a std::panic::Location<'a>>,
@@ -12,9 +12,9 @@ impl fmt::Display for LocationSection<'_> {
         let theme = self.1;
         // If known, print panic location.
         if let Some(loc) = self.0 {
-            write!(f, "{}", style_if_possible(loc.file(), theme.panic_file))?;
+            write!(f, "{}", style(loc.file(), theme.panic_file))?;
             write!(f, ":")?;
-            write!(f, "{}", style_if_possible(&loc.line(), theme.panic_line_number))?;
+            write!(f, "{}", style(loc.line(), theme.panic_line_number))?;
         } else {
             write!(f, "<unknown>")?;
         }

--- a/color-eyre/src/fmt.rs
+++ b/color-eyre/src/fmt.rs
@@ -1,7 +1,6 @@
 //! Module for new types that isolate complext formatting
 use std::fmt;
-
-use owo_colors::OwoColorize;
+use crate::style_if_possible;
 
 pub(crate) struct LocationSection<'a>(
     pub(crate) Option<&'a std::panic::Location<'a>>,
@@ -13,9 +12,9 @@ impl fmt::Display for LocationSection<'_> {
         let theme = self.1;
         // If known, print panic location.
         if let Some(loc) = self.0 {
-            write!(f, "{}", loc.file().style(theme.panic_file))?;
+            write!(f, "{}", style_if_possible(loc.file(), theme.panic_file))?;
             write!(f, ":")?;
-            write!(f, "{}", loc.line().style(theme.panic_line_number))?;
+            write!(f, "{}", style_if_possible(&loc.line(), theme.panic_line_number))?;
         } else {
             write!(f, "<unknown>")?;
         }

--- a/color-eyre/src/fmt.rs
+++ b/color-eyre/src/fmt.rs
@@ -14,9 +14,9 @@ impl fmt::Display for LocationSection<'_> {
         if let Some(loc) = self.0 {
             write!(f, "{}", style(loc.file(), theme.panic_file))?;
             write!(f, ":")?;
-            write!(f, "{}", style(&loc.line(), theme.panic_line_number))?;
+            write!(f, "{}", style(loc.line(), theme.panic_line_number))?;
             write!(f, ":")?;
-            write!(f, "{}", style(&loc.column(), theme.panic_line_number))?;
+            write!(f, "{}", style(loc.column(), theme.panic_line_number))?;
         } else {
             write!(f, "<unknown>")?;
         }

--- a/color-eyre/src/fmt.rs
+++ b/color-eyre/src/fmt.rs
@@ -1,7 +1,6 @@
 //! Module for new types that isolate complext formatting
+use crate::style;
 use std::fmt;
-
-use owo_colors::OwoColorize;
 
 pub(crate) struct LocationSection<'a>(
     pub(crate) Option<&'a std::panic::Location<'a>>,
@@ -13,11 +12,11 @@ impl fmt::Display for LocationSection<'_> {
         let theme = self.1;
         // If known, print panic location.
         if let Some(loc) = self.0 {
-            write!(f, "{}", loc.file().style(theme.panic_file))?;
+            write!(f, "{}", style(loc.file(), theme.panic_file))?;
             write!(f, ":")?;
-            write!(f, "{}", loc.line().style(theme.panic_line_number))?;
+            write!(f, "{}", style(&loc.line(), theme.panic_line_number))?;
             write!(f, ":")?;
-            write!(f, "{}", loc.column().style(theme.panic_line_number))?;
+            write!(f, "{}", style(&loc.column(), theme.panic_line_number))?;
         } else {
             write!(f, "<unknown>")?;
         }

--- a/color-eyre/src/handler.rs
+++ b/color-eyre/src/handler.rs
@@ -1,6 +1,7 @@
 use crate::{
     config::BacktraceFormatter,
     section::help::HelpInfo,
+    style_if_possible,
     writers::{EnvSection, WriterExt},
     Handler,
 };
@@ -62,7 +63,7 @@ impl eyre::EyreHandler for Handler {
 
         for (n, error) in errors() {
             writeln!(f)?;
-            write!(indented(f).ind(n), "{}", self.theme.error.style(error))?;
+            write!(indented(f).ind(n), "{}", style_if_possible(error, self.theme.error))?;
         }
 
         let mut separated = f.header("\n\n");

--- a/color-eyre/src/handler.rs
+++ b/color-eyre/src/handler.rs
@@ -1,7 +1,7 @@
 use crate::{
     config::BacktraceFormatter,
     section::help::HelpInfo,
-    style_if_possible,
+    style,
     writers::{EnvSection, WriterExt},
     Handler,
 };
@@ -63,7 +63,7 @@ impl eyre::EyreHandler for Handler {
 
         for (n, error) in errors() {
             writeln!(f)?;
-            write!(indented(f).ind(n), "{}", style_if_possible(error, self.theme.error))?;
+            write!(indented(f).ind(n), "{}", style(error, self.theme.error))?;
         }
 
         let mut separated = f.header("\n\n");

--- a/color-eyre/src/handler.rs
+++ b/color-eyre/src/handler.rs
@@ -2,6 +2,7 @@ use crate::{
     Handler,
     config::BacktraceFormatter,
     section::help::HelpInfo,
+    style,
     writers::{EnvSection, WriterExt},
 };
 use backtrace::Backtrace;
@@ -62,7 +63,7 @@ impl eyre::EyreHandler for Handler {
 
         for (n, error) in errors() {
             writeln!(f)?;
-            write!(indented(f).ind(n), "{}", self.theme.error.style(error))?;
+            write!(indented(f).ind(n), "{}", style(error, self.theme.error))?;
         }
 
         let mut separated = f.header("\n\n");

--- a/color-eyre/src/lib.rs
+++ b/color-eyre/src/lib.rs
@@ -364,6 +364,7 @@
 
 use std::sync::Arc;
 
+use anstream::AutoStream;
 use backtrace::Backtrace;
 pub use eyre;
 #[doc(hidden)]
@@ -371,6 +372,8 @@ pub use eyre::Report;
 #[doc(hidden)]
 pub use eyre::Result;
 pub use owo_colors;
+use owo_colors::OwoColorize;
+use owo_colors::Style;
 use section::help::HelpInfo;
 #[doc(hidden)]
 pub use section::Section as Help;
@@ -461,4 +464,18 @@ pub enum ErrorKind<'a> {
 /// ```
 pub fn install() -> Result<(), crate::eyre::Report> {
     config::HookBuilder::default().install()
+}
+
+/// Apply owo_colors style if possible. Returns a string with/without ANSI
+/// escape symbols.
+fn style_if_possible<S>(str: S, style: Style) -> String
+where
+    S: ToString + std::fmt::Display,
+{
+    let color_choice = AutoStream::choice(&std::io::stderr());
+
+    match color_choice {
+        anstream::ColorChoice::Never => str.to_string(),
+        _ => str.style(style).to_string(),
+    }
 }

--- a/color-eyre/src/lib.rs
+++ b/color-eyre/src/lib.rs
@@ -468,7 +468,7 @@ pub fn install() -> Result<(), crate::eyre::Report> {
 
 /// Apply owo_colors style if possible. Returns a string with/without ANSI
 /// escape symbols.
-fn style_if_possible<S>(str: S, style: Style) -> String
+fn style<S>(str: S, style: Style) -> String
 where
     S: ToString + std::fmt::Display,
 {

--- a/color-eyre/src/lib.rs
+++ b/color-eyre/src/lib.rs
@@ -361,6 +361,7 @@ use std::sync::Arc;
 
 #[doc(hidden)]
 pub use Handler as Context;
+use anstream::AutoStream;
 use backtrace::Backtrace;
 pub use eyre;
 #[doc(hidden)]
@@ -368,6 +369,8 @@ pub use eyre::Report;
 #[doc(hidden)]
 pub use eyre::Result;
 pub use owo_colors;
+use owo_colors::OwoColorize;
+use owo_colors::Style;
 #[doc(hidden)]
 pub use section::Section as Help;
 use section::help::HelpInfo;
@@ -457,4 +460,18 @@ pub enum ErrorKind<'a> {
 /// ```
 pub fn install() -> Result<(), crate::eyre::Report> {
     config::HookBuilder::default().install()
+}
+
+/// Apply owo_colors style if possible. Returns a string with/without ANSI
+/// escape symbols.
+fn style<S>(str: S, style: Style) -> String
+where
+    S: ToString + std::fmt::Display,
+{
+    let color_choice = AutoStream::choice(&std::io::stderr());
+
+    match color_choice {
+        anstream::ColorChoice::Never => str.to_string(),
+        _ => str.style(style).to_string(),
+    }
 }

--- a/color-eyre/src/section/help.rs
+++ b/color-eyre/src/section/help.rs
@@ -2,8 +2,7 @@
 use crate::{
     config::Theme,
     eyre::{Report, Result},
-    style_if_possible,
-    Section,
+    style, Section,
 };
 use indenter::indented;
 use std::fmt::Write;
@@ -261,18 +260,18 @@ impl Display for HelpInfo {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             HelpInfo::Note(note, theme) => {
-                write!(f, "{}: {}", style_if_possible("Note", theme.help_info_note), note)
+                write!(f, "{}: {}", style("Note", theme.help_info_note), note)
             }
             HelpInfo::Warning(warning, theme) => write!(
                 f,
                 "{}: {}",
-                style_if_possible("Warning", theme.help_info_warning),
+                style("Warning", theme.help_info_warning),
                 warning
             ),
             HelpInfo::Suggestion(suggestion, theme) => write!(
                 f,
                 "{}: {}",
-                style_if_possible("Suggestion", theme.help_info_suggestion),
+                style("Suggestion", theme.help_info_suggestion),
                 suggestion
             ),
             HelpInfo::Custom(section) => write!(f, "{section}"),
@@ -286,7 +285,11 @@ impl Display for HelpInfo {
                 write!(f, "Error:")?;
                 for (n, error) in errors.enumerate() {
                     writeln!(f)?;
-                    write!(indented(f).ind(n), "{}", style_if_possible(error, theme.help_info_error))?;
+                    write!(
+                        indented(f).ind(n),
+                        "{}",
+                        style(error, theme.help_info_error)
+                    )?;
                 }
 
                 Ok(())

--- a/color-eyre/src/section/help.rs
+++ b/color-eyre/src/section/help.rs
@@ -2,10 +2,10 @@
 use crate::{
     config::Theme,
     eyre::{Report, Result},
+    style_if_possible,
     Section,
 };
 use indenter::indented;
-use owo_colors::OwoColorize;
 use std::fmt::Write;
 use std::fmt::{self, Display};
 
@@ -261,18 +261,18 @@ impl Display for HelpInfo {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             HelpInfo::Note(note, theme) => {
-                write!(f, "{}: {}", "Note".style(theme.help_info_note), note)
+                write!(f, "{}: {}", style_if_possible("Note", theme.help_info_note), note)
             }
             HelpInfo::Warning(warning, theme) => write!(
                 f,
                 "{}: {}",
-                "Warning".style(theme.help_info_warning),
+                style_if_possible("Warning", theme.help_info_warning),
                 warning
             ),
             HelpInfo::Suggestion(suggestion, theme) => write!(
                 f,
                 "{}: {}",
-                "Suggestion".style(theme.help_info_suggestion),
+                style_if_possible("Suggestion", theme.help_info_suggestion),
                 suggestion
             ),
             HelpInfo::Custom(section) => write!(f, "{section}"),
@@ -286,7 +286,7 @@ impl Display for HelpInfo {
                 write!(f, "Error:")?;
                 for (n, error) in errors.enumerate() {
                     writeln!(f)?;
-                    write!(indented(f).ind(n), "{}", error.style(theme.help_info_error))?;
+                    write!(indented(f).ind(n), "{}", style_if_possible(error, theme.help_info_error))?;
                 }
 
                 Ok(())

--- a/color-eyre/src/section/help.rs
+++ b/color-eyre/src/section/help.rs
@@ -3,9 +3,9 @@ use crate::{
     Section,
     config::Theme,
     eyre::{Report, Result},
+    style,
 };
 use indenter::indented;
-use owo_colors::OwoColorize;
 use std::fmt::Write;
 use std::fmt::{self, Display};
 
@@ -261,18 +261,18 @@ impl Display for HelpInfo {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             HelpInfo::Note(note, theme) => {
-                write!(f, "{}: {}", "Note".style(theme.help_info_note), note)
+                write!(f, "{}: {}", style("Note", theme.help_info_note), note)
             }
             HelpInfo::Warning(warning, theme) => write!(
                 f,
                 "{}: {}",
-                "Warning".style(theme.help_info_warning),
+                style("Warning", theme.help_info_warning),
                 warning
             ),
             HelpInfo::Suggestion(suggestion, theme) => write!(
                 f,
                 "{}: {}",
-                "Suggestion".style(theme.help_info_suggestion),
+                style("Suggestion", theme.help_info_suggestion),
                 suggestion
             ),
             HelpInfo::Custom(section) => write!(f, "{section}"),
@@ -286,7 +286,11 @@ impl Display for HelpInfo {
                 write!(f, "Error:")?;
                 for (n, error) in errors.enumerate() {
                     writeln!(f)?;
-                    write!(indented(f).ind(n), "{}", error.style(theme.help_info_error))?;
+                    write!(
+                        indented(f).ind(n),
+                        "{}",
+                        style(error, theme.help_info_error)
+                    )?;
                 }
 
                 Ok(())

--- a/color-eyre/tests/theme.rs
+++ b/color-eyre/tests/theme.rs
@@ -295,8 +295,8 @@ fn setup() {
     use owo_colors::style;
     let styles = color_eyre::config::Styles::dark()
         // ^ or, instead of `dark`, use `new` for blank styles or `light` if you what to derive from a light theme. Now configure your styles (see the docs for all options):
-        .line_number(style().blue())
-        .help_info_suggestion(style().red());
+        .line_number(Style::new().blue())
+        .help_info_suggestion(Style::new().red());
 
     color_eyre::config::HookBuilder::new()
         .styles(styles)

--- a/color-eyre/tests/theme.rs
+++ b/color-eyre/tests/theme.rs
@@ -298,8 +298,8 @@ fn setup() {
     use owo_colors::style;
     let styles = color_eyre::config::Styles::dark()
         // ^ or, instead of `dark`, use `new` for blank styles or `light` if you what to derive from a light theme. Now configure your styles (see the docs for all options):
-        .line_number(style().blue())
-        .help_info_suggestion(style().red());
+        .line_number(Style::new().blue())
+        .help_info_suggestion(Style::new().red());
 
     color_eyre::config::HookBuilder::new()
         .styles(styles)

--- a/color-eyre/tests/theme.rs
+++ b/color-eyre/tests/theme.rs
@@ -128,6 +128,12 @@ fn test_panic_backwards_compatibility() {
         .args(&features)
         .env("RUSTFLAGS", "-Awarnings")
         .env("CARGO_FUTURE_INCOMPAT_REPORT_FREQUENCY", "never")
+        // Colors are emitted only when the output stream supports them; the
+        // helper's stderr is a pipe, so force them on to match the colored
+        // control data. `CARGO_TERM_COLOR=never` keeps `cargo`'s own progress
+        // lines uncolored so they don't add stray ANSI to the comparison.
+        .env("CLICOLOR_FORCE", "1")
+        .env("CARGO_TERM_COLOR", "never")
         .output()
         .expect("failed to execute process");
     let target = String::from_utf8(output.stderr).expect("failed to convert output to `String`");
@@ -256,6 +262,10 @@ fn test_backwards_compatibility(target: String, file_name: &str) {
 
 fn setup() {
     unsafe { std::env::set_var("RUST_LIB_BACKTRACE", "1") };
+    // Colors are emitted only when the output stream supports them; under
+    // `cargo test` stderr is a pipe, so force them on to match the colored
+    // control data.
+    unsafe { std::env::set_var("CLICOLOR_FORCE", "1") };
 
     #[cfg(feature = "capture-spantrace")]
     {

--- a/color-spantrace/Cargo.toml
+++ b/color-spantrace/Cargo.toml
@@ -17,6 +17,7 @@ tracing-error = "0.2.0"
 tracing-core = "0.1.21"
 owo-colors = { workspace = true }
 once_cell = { workspace = true }
+anstream = { workspace = true }
 
 [dev-dependencies]
 tracing-subscriber = "0.3.4"

--- a/color-spantrace/Cargo.toml
+++ b/color-spantrace/Cargo.toml
@@ -16,6 +16,7 @@ include = { workspace = true }
 tracing-error = "0.2.0"
 tracing-core = "0.1.21"
 owo-colors = { workspace = true }
+anstream = { workspace = true }
 
 [dev-dependencies]
 tracing-subscriber = "0.3.4"

--- a/color-spantrace/src/lib.rs
+++ b/color-spantrace/src/lib.rs
@@ -278,19 +278,15 @@ impl Frame<'_> {
             f,
             "{:>2}: {}{}{}",
             i,
-            style_if_possible(self.metadata.target(), self.theme.target),
-            style_if_possible("::", self.theme.target),
-            style_if_possible(self.metadata.name(), self.theme.target),
+            style(self.metadata.target(), self.theme.target),
+            style("::", self.theme.target),
+            style(self.metadata.name(), self.theme.target),
         )
     }
 
     fn print_fields(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if !self.fields.is_empty() {
-            write!(
-                f,
-                " with {}",
-                style_if_possible(self.fields, self.theme.fields)
-            )?;
+            write!(f, " with {}", style(self.fields, self.theme.fields))?;
         }
 
         Ok(())
@@ -305,8 +301,8 @@ impl Frame<'_> {
             write!(
                 f,
                 "\n    at {}:{}",
-                style_if_possible(file, self.theme.file),
-                style_if_possible(lineno, self.theme.line_number),
+                style(file, self.theme.file),
+                style(lineno, self.theme.line_number),
             )?;
         } else {
             write!(f, "\n    at <unknown source file>")?;
@@ -343,7 +339,7 @@ impl Frame<'_> {
                     cur_line_no.to_string(),
                     line.unwrap()
                 )?;
-                write!(f, "\n{}", style_if_possible(&buf, self.theme.active_line))?;
+                write!(f, "\n{}", style(&buf, self.theme.active_line))?;
                 buf.clear();
             } else {
                 write!(f, "\n{:>8} │ {}", cur_line_no, line.unwrap())?;
@@ -387,7 +383,7 @@ impl fmt::Display for ColorSpanTrace<'_> {
 
 /// Apply owo_colors style if possible. Returns a string with/without ANSI
 /// escape symbols.
-fn style_if_possible<S>(str: S, style: Style) -> String
+fn style<S>(str: S, style: Style) -> String
 where
     S: ToString + std::fmt::Display,
 {

--- a/color-spantrace/src/lib.rs
+++ b/color-spantrace/src/lib.rs
@@ -89,7 +89,7 @@
 
 use anstream::AutoStream;
 use once_cell::sync::OnceCell;
-use owo_colors::{style, OwoColorize, Style};
+use owo_colors::{OwoColorize, Style};
 use std::env;
 use std::fmt;
 use std::fs::File;
@@ -117,11 +117,11 @@ impl Theme {
     /// A theme for a dark background. This is the default
     pub fn dark() -> Self {
         Self {
-            file: style().purple(),
-            line_number: style().purple(),
-            active_line: style().white().bold(),
-            target: style().bright_red(),
-            fields: style().bright_cyan(),
+            file: Style::new().purple(),
+            line_number: Style::new().purple(),
+            active_line: Style::new().white().bold(),
+            target: Style::new().bright_red(),
+            fields: Style::new().bright_cyan(),
         }
     }
 
@@ -129,11 +129,11 @@ impl Theme {
     /// A theme for a light background
     pub fn light() -> Self {
         Self {
-            file: style().purple(),
-            line_number: style().purple(),
-            target: style().red(),
-            fields: style().blue(),
-            active_line: style().bold(),
+            file: Style::new().purple(),
+            line_number: Style::new().purple(),
+            target: Style::new().red(),
+            fields: Style::new().blue(),
+            active_line: Style::new().bold(),
         }
     }
 

--- a/color-spantrace/src/lib.rs
+++ b/color-spantrace/src/lib.rs
@@ -83,7 +83,7 @@
 )]
 
 use anstream::AutoStream;
-use owo_colors::{OwoColorize, Style, style};
+use owo_colors::{OwoColorize, Style};
 use std::env;
 use std::fmt;
 use std::fs::File;
@@ -112,11 +112,11 @@ impl Theme {
     /// A theme for a dark background. This is the default
     pub fn dark() -> Self {
         Self {
-            file: style().purple(),
-            line_number: style().purple(),
-            active_line: style().white().bold(),
-            target: style().bright_red(),
-            fields: style().bright_cyan(),
+            file: Style::new().purple(),
+            line_number: Style::new().purple(),
+            active_line: Style::new().white().bold(),
+            target: Style::new().bright_red(),
+            fields: Style::new().bright_cyan(),
         }
     }
 
@@ -124,11 +124,11 @@ impl Theme {
     /// A theme for a light background
     pub fn light() -> Self {
         Self {
-            file: style().purple(),
-            line_number: style().purple(),
-            target: style().red(),
-            fields: style().blue(),
-            active_line: style().bold(),
+            file: Style::new().purple(),
+            line_number: Style::new().purple(),
+            target: Style::new().red(),
+            fields: Style::new().blue(),
+            active_line: Style::new().bold(),
         }
     }
 

--- a/color-spantrace/src/lib.rs
+++ b/color-spantrace/src/lib.rs
@@ -82,7 +82,8 @@
     while_true
 )]
 
-use owo_colors::{Style, style};
+use anstream::AutoStream;
+use owo_colors::{OwoColorize, Style, style};
 use std::env;
 use std::fmt;
 use std::fs::File;
@@ -272,15 +273,15 @@ impl Frame<'_> {
             f,
             "{:>2}: {}{}{}",
             i,
-            self.theme.target.style(self.metadata.target()),
-            self.theme.target.style("::"),
-            self.theme.target.style(self.metadata.name()),
+            style(self.metadata.target(), self.theme.target),
+            style("::", self.theme.target),
+            style(self.metadata.name(), self.theme.target),
         )
     }
 
     fn print_fields(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if !self.fields.is_empty() {
-            write!(f, " with {}", self.theme.fields.style(self.fields))?;
+            write!(f, " with {}", style(self.fields, self.theme.fields))?;
         }
 
         Ok(())
@@ -295,8 +296,8 @@ impl Frame<'_> {
             write!(
                 f,
                 "\n    at {}:{}",
-                self.theme.file.style(file),
-                self.theme.line_number.style(lineno),
+                style(file, self.theme.file),
+                style(lineno, self.theme.line_number),
             )?;
         } else {
             write!(f, "\n    at <unknown source file>")?;
@@ -333,7 +334,7 @@ impl Frame<'_> {
                     cur_line_no.to_string(),
                     line.unwrap()
                 )?;
-                write!(f, "\n{}", self.theme.active_line.style(&buf))?;
+                write!(f, "\n{}", style(&buf, self.theme.active_line))?;
                 buf.clear();
             } else {
                 write!(f, "\n{:>8} │ {}", cur_line_no, line.unwrap())?;
@@ -372,5 +373,19 @@ impl fmt::Display for ColorSpanTrace<'_> {
         });
 
         err
+    }
+}
+
+/// Apply owo_colors style if possible. Returns a string with/without ANSI
+/// escape symbols.
+fn style<S>(str: S, style: Style) -> String
+where
+    S: ToString + std::fmt::Display,
+{
+    let color_choice = AutoStream::choice(&std::io::stderr());
+
+    match color_choice {
+        anstream::ColorChoice::Never => str.to_string(),
+        _ => str.style(style).to_string(),
     }
 }

--- a/color-spantrace/tests/themes.rs
+++ b/color-spantrace/tests/themes.rs
@@ -53,6 +53,10 @@ fn test_backwards_compatibility() {
     use tracing_error::ErrorLayer;
     use tracing_subscriber::{prelude::*, registry::Registry};
     unsafe { std::env::set_var("RUST_LIB_BACKTRACE", "full") };
+    // Colors are emitted only when the output stream supports them; under
+    // `cargo test` stderr is a pipe, so force them on to match the colored
+    // control data.
+    unsafe { std::env::set_var("CLICOLOR_FORCE", "1") };
 
     // This integration is ran by cargo with cwd="color-spantrace", but the string literals for
     // `file!` are relative to the workspace root. This changes the cwd to the workspace root.


### PR DESCRIPTION
Closes #236.
Closes #237.

This PR wraps all calls to `owo_colors::OwoColorize::style` with function that calls `anstream::AutoStream::choice` and checks whenever colors are available for the current stderr.

### Conserns

The stderr here is hardcoded it that somewhat bothers me. It is possible for that user of eyre to configure printing all of the error messages into the stderr? Because if eyre ever prints color to the stdout and then the user redirects stdout to the file, [this check](https://github.com/eyre-rs/eyre/blob/99576ecac083080e9668472b2d7b18e301ec2ad0/color-spantrace/src/lib.rs#L392) would detect that stderr is still a terminal and allow ANSI symbols to be printed to the file. 

I am also wondering if duplicating `style_if_possible` in `color-spantrace` and `color-eyre` is okay. Should I move it somewhere else?

### Tests

I've done some quick testing by running examples and this seems to work well. I don't see any colors in the terminal and there are no special symbols _from eyre_ when redirecting to the file.

Here is a script to run all color-eyre examples and print the output to the file. Mind that `RUSTFLAGS=-Awarnings` will force everything to rebuild. But that saves you from scrolling past all the deprecation warnings (fixed here btw — https://github.com/eyre-rs/eyre/pull/235).

```bash
#!/bin/env bash

TEST_OUTPUT_DIR=test-no-color-examples
EXAMPLES='custom_filter custom_section debug_perf github_issue multiple_errors panic_compose panic_hook theme_test_helper theme color-eyre-usage'

rm -r $TEST_OUTPUT_DIR || true
mkdir -p $TEST_OUTPUT_DIR

for example in $EXAMPLES; do
    RUSTFLAGS=-Awarnings cargo run --example $example &>> $TEST_OUTPUT_DIR/$example
done
```

Might be nice to write some unit tests, but I'd prefer if someone else did it.

### About tracing_subscriber

The only ANSI symbols I see are the ones coming from tracing_subscriber ([color-eyre/examples/theme_test_helper.rs:35](https://github.com/eyre-rs/eyre/blob/master/color-eyre/examples/theme_test_helper.rs#L35)). I did a little digging and found that removing this layer [color-eyre/examples/theme_test_helper.rs:49](https://github.com/eyre-rs/eyre/blob/master/color-eyre/examples/theme_test_helper.rs#L49) from registry fixes the issue.

The colors are still there, in the terminal, but not in the file. The only thing that changed visually is that the text is no longer cursive. Although I don't quite understand what this layer does and why is it needed. The [documentation](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/struct.Layer.html#method.with_target) is not clear to me.

I think we should just remove this layer from every example to avoid teaching people this flawed behaviour. Let's leave it up to them to enable this layer. This way it won't be eyre's problem, but tracing_subscriber's one.

### Rant about owo_colors

To be fair, this all feels like a huge blunder from owo_colors. I feel like it is it who should be responsible for detecting colors. They already have a `supports-color` feature. But enabling it only gives you a method that you should apply everywhere yourself. I can understand why this feature isn't turned on by default, sure. But once I enable it I kind of expect everything to work out of the box. What if you have thousands of lines of code where colors are added? Do you wrap everything with `if_supports_color`??? This is nonsense.