### PR TITLE
Rename `ok_or_eyre` to `ok_or_report` in `OptionExt` trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,13 +231,13 @@ implies that you're creating a new error that saves the old error as its
 `source`. With `Option` there is no source error to wrap, so `wrap_err` ends up
 being somewhat meaningless.
 
-Instead `eyre` offers [`OptionExt::ok_or_eyre`] to yield _static_ errors from `None`,
+Instead `eyre` offers [`OptionExt::ok_or_report`] to yield _static_ errors from `None`,
 and intends for users to use the combinator functions provided by
 `std`, converting `Option`s to `Result`s, for _dynamic_ errors.
 So where you would write this with
 anyhow:
 
-[`OptionExt::ok_or_eyre`]: https://docs.rs/eyre/latest/eyre/trait.OptionExt.html#tymethod.ok_or_eyre
+[`OptionExt::ok_or_report`]: https://docs.rs/eyre/latest/eyre/trait.OptionExt.html#tymethod.ok_or_report
 
 ```rust
 use anyhow::Context;
@@ -253,7 +253,7 @@ With `eyre` we want users to write:
 use eyre::{eyre, OptionExt, Result};
 
 let opt: Option<()> = None;
-let result_static: Result<()> = opt.ok_or_eyre("static error message");
+let result_static: Result<()> = opt.ok_or_report("static error message");
 let result_dynamic: Result<()> = opt.ok_or_else(|| eyre!("{} error message", "dynamic"));
 ```
 

--- a/eyre/CHANGELOG.md
+++ b/eyre/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - tl;dr: `wrap_err_with` is faster unless the constructed error object already exists
 - ~~automated conversion to external errors for ensure! and bail! [by j-baker](https://github.com/eyre-rs/eyre/pull/95)~~ breaking change: shelved for next major release
 - eyre::Ok for generating eyre::Ok() without fully specifying the type [by kylewlacy](https://github.com/eyre-rs/eyre/pull/91)
-- `OptionExt::ok_or_eyre` for yielding static `Report`s from `None` [by LeoniePhiline](https://github.com/eyre-rs/eyre/pull/125)
+- `OptionExt::ok_or_report` for yielding static `Report`s from `None` [by LeoniePhiline](https://github.com/eyre-rs/eyre/pull/125)
 
 ### New Contributors
 - @sharnoff made their first contribution in https://github.com/eyre-rs/eyre/pull/86

--- a/eyre/src/lib.rs
+++ b/eyre/src/lib.rs
@@ -283,7 +283,7 @@
 //! `source`. With `Option` there is no source error to wrap, so `wrap_err` ends up
 //! being somewhat meaningless.
 //!
-//! Instead `eyre` offers [`OptionExt::ok_or_eyre`] to yield _static_ errors from `None`,
+//! Instead `eyre` offers [`OptionExt::ok_or_report`] to yield _static_ errors from `None`,
 //! and intends for users to use the combinator functions provided by
 //! `std`, converting `Option`s to `Result`s, for _dynamic_ errors.
 //! So where you would write this with
@@ -306,7 +306,7 @@
 //! # eyre::set_hook(Box::new(eyre::DefaultHandler::default_with)).unwrap();
 //! #
 //! let opt: Option<()> = None;
-//! let result_static: Result<()> = opt.ok_or_eyre("static error message");
+//! let result_static: Result<()> = opt.ok_or_report("static error message");
 //! let result_dynamic: Result<()> = opt.ok_or_else(|| eyre!("{} error message", "dynamic"));
 //! ```
 //!
@@ -1125,7 +1125,7 @@ pub trait WrapErr<T, E>: context::private::Sealed {
         F: FnOnce() -> D;
 }
 
-/// Provides the [`ok_or_eyre`][OptionExt::ok_or_eyre] method for [`Option`].
+/// Provides the [`ok_or_report`][OptionExt::ok_or_report] method for [`Option`].
 ///
 /// This trait is sealed and cannot be implemented for types outside of
 /// `eyre`.
@@ -1139,12 +1139,12 @@ pub trait WrapErr<T, E>: context::private::Sealed {
 ///
 /// let option: Option<()> = None;
 ///
-/// let result = option.ok_or_eyre("static str error");
+/// let result = option.ok_or_report("static str error");
 ///
 /// assert_eq!(result.unwrap_err().to_string(), "static str error");
 /// ```
 ///
-/// # `ok_or_eyre` vs `ok_or_else`
+/// # `ok_or_report` vs `ok_or_else`
 ///
 /// If string interpolation is required for the generated [report][Report],
 /// use [`ok_or_else`][Option::ok_or_else] instead,
@@ -1162,7 +1162,7 @@ pub trait WrapErr<T, E>: context::private::Sealed {
 /// assert_eq!(result.unwrap_err().to_string(), "dynamic error");
 /// ```
 ///
-/// `ok_or_eyre` incurs no runtime cost, as the error object
+/// `ok_or_report` incurs no runtime cost, as the error object
 /// is constructed from the provided static argument
 /// only in the `None` case.
 pub trait OptionExt<T>: context::private::Sealed {
@@ -1170,12 +1170,12 @@ pub trait OptionExt<T>: context::private::Sealed {
     /// mapping [`Some(v)`][Option::Some] to [`Ok(v)`][Result::Ok]
     /// and [`None`] to [`Report`].
     ///
-    /// `ok_or_eyre` allows for eyre [`Report`] error objects
+    /// `ok_or_report` allows for eyre [`Report`] error objects
     /// to be lazily created from static messages in the `None` case.
     ///
     /// For dynamic error messages, use [`ok_or_else`][Option::ok_or_else],
     /// invoking [`eyre!`] in the closure to perform string interpolation.
-    fn ok_or_eyre<M>(self, message: M) -> crate::Result<T>
+    fn ok_or_report<M>(self, message: M) -> crate::Result<T>
     where
         M: Debug + Display + Send + Sync + 'static;
 }

--- a/eyre/src/option.rs
+++ b/eyre/src/option.rs
@@ -3,7 +3,7 @@ use core::fmt::{Debug, Display};
 
 impl<T> OptionExt<T> for Option<T> {
     #[track_caller]
-    fn ok_or_eyre<M>(self, message: M) -> crate::Result<T>
+    fn ok_or_report<M>(self, message: M) -> crate::Result<T>
     where
         M: Debug + Display + Send + Sync + 'static,
     {

--- a/eyre/tests/test_location.rs
+++ b/eyre/tests/test_location.rs
@@ -84,14 +84,14 @@ fn test_wrap_err_with() {
 }
 
 #[test]
-fn test_option_ok_or_eyre() {
+fn test_option_ok_or_report() {
     let _ = eyre::set_hook(Box::new(|_e| {
         let expected_location = file!();
         Box::new(LocationHandler::new(expected_location))
     }));
 
     use eyre::OptionExt;
-    let err = None::<()>.ok_or_eyre("oopsie").unwrap_err();
+    let err = None::<()>.ok_or_report("oopsie").unwrap_err();
 
     // should panic if the location isn't in our crate
     println!("{err:?}");

--- a/eyre/tests/test_option.rs
+++ b/eyre/tests/test_option.rs
@@ -4,12 +4,12 @@ use self::common::maybe_install_handler;
 use eyre::OptionExt;
 
 #[test]
-fn test_option_ok_or_eyre() {
+fn test_option_ok_or_report() {
     maybe_install_handler().unwrap();
 
     let option: Option<()> = None;
 
-    let result = option.ok_or_eyre("static str error");
+    let result = option.ok_or_report("static str error");
 
     assert_eq!(result.unwrap_err().to_string(), "static str error");
 }


### PR DESCRIPTION
Considering eyre plans to release 1.0 some time soon (https://github.com/eyre-rs/eyre/pull/269), it's a good time to clean up the API

After renaming `eyre!` to `report!` (https://github.com/eyre-rs/eyre/pull/271), renaming `ok_or_eyre` to `ok_or_report` will mean we are consistent with the naming of `ok_or_report` method, and have more of a parallel between static error creation in the `None` case of an option, and **dynamic** error creation:

```rust
opt.ok_or_report("failed reading file")
```

```rust
opt.ok_or_else(|| report!("failed reading file: {path}"))
``` 