### PR TITLE
feat: re-export everything from eyre

### DIFF
--- a/color-eyre/README.md
+++ b/color-eyre/README.md
@@ -32,7 +32,7 @@ color-eyre = "0.6"
 And install the panic and error report handlers:
 
 ```rust
-use color_eyre::eyre::Result;
+use color_eyre::Result;
 
 fn main() -> Result<()> {
     color_eyre::install()?;
@@ -129,7 +129,7 @@ to contain `stderr` and `stdout` from a failed command, taken from
 [`examples/custom_section.rs`]:
 
 ```rust
-use color_eyre::{eyre::eyre, SectionExt, Section, eyre::Report};
+use color_eyre::{eyre, SectionExt, Section, Report};
 use std::process::Command;
 use tracing::instrument;
 

--- a/color-eyre/examples/custom_filter.rs
+++ b/color-eyre/examples/custom_filter.rs
@@ -1,4 +1,4 @@
-use color_eyre::{Section, eyre::Report, eyre::ResultExt};
+use color_eyre::{Report, ResultExt, Section};
 use tracing::{info, instrument};
 
 #[instrument]

--- a/color-eyre/examples/custom_section.rs
+++ b/color-eyre/examples/custom_section.rs
@@ -1,7 +1,5 @@
 use color_eyre::{
-    Section, SectionExt,
-    eyre::Report,
-    eyre::{ResultExt, eyre},
+    Report, Section, SectionExt, {ResultExt, eyre},
 };
 use std::process::Command;
 use tracing::instrument;

--- a/color-eyre/examples/debug_perf.rs
+++ b/color-eyre/examples/debug_perf.rs
@@ -1,10 +1,6 @@
 //! example for manually testing the perf of color-eyre in debug vs release
 
-use color_eyre::{
-    Section,
-    eyre::Report,
-    eyre::{ResultExt, eyre},
-};
+use color_eyre::{Report, ResultExt, Section, eyre};
 use tracing::instrument;
 
 fn main() -> Result<(), Report> {

--- a/color-eyre/examples/github_issue.rs
+++ b/color-eyre/examples/github_issue.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code, unused_imports)]
-use color_eyre::eyre;
-use eyre::{Report, Result};
+use color_eyre::{
+    eyre, {Report, Result},
+};
 use tracing::instrument;
 
 #[instrument]

--- a/color-eyre/examples/multiple_errors.rs
+++ b/color-eyre/examples/multiple_errors.rs
@@ -1,4 +1,4 @@
-use color_eyre::{Section, eyre::Report, eyre::eyre};
+use color_eyre::{Report, Section, eyre};
 use thiserror::Error;
 
 fn main() -> Result<(), Report> {

--- a/color-eyre/examples/panic_compose.rs
+++ b/color-eyre/examples/panic_compose.rs
@@ -1,4 +1,4 @@
-use color_eyre::eyre::Report;
+use color_eyre::Report;
 use tracing::instrument;
 
 #[instrument]

--- a/color-eyre/examples/panic_hook.rs
+++ b/color-eyre/examples/panic_hook.rs
@@ -1,4 +1,4 @@
-use color_eyre::eyre::Report;
+use color_eyre::Report;
 use tracing::instrument;
 
 #[instrument]

--- a/color-eyre/examples/theme.rs
+++ b/color-eyre/examples/theme.rs
@@ -1,4 +1,4 @@
-use color_eyre::{Section, config::Theme, eyre::Report, owo_colors::style};
+use color_eyre::{Report, Section, config::Theme, owo_colors::style};
 
 /// To experiment with theme values, edit `theme()` below and execute `cargo run --example theme`
 fn theme() -> Theme {

--- a/color-eyre/examples/theme_test_helper.rs
+++ b/color-eyre/examples/theme_test_helper.rs
@@ -4,7 +4,7 @@
 
 //! See "tests/theme.rs" for more information.
 
-use color_eyre::{Section, eyre::Report};
+use color_eyre::{Report, Section};
 
 #[rustfmt::skip]
 #[derive(Debug, thiserror::Error)]

--- a/color-eyre/examples/usage.rs
+++ b/color-eyre/examples/usage.rs
@@ -1,4 +1,4 @@
-use color_eyre::{Section, eyre::Report, eyre::ResultExt};
+use color_eyre::{Report, ResultExt, Section};
 use tracing::{info, instrument};
 
 #[instrument]

--- a/color-eyre/src/config.rs
+++ b/color-eyre/src/config.rs
@@ -420,9 +420,7 @@ impl HookBuilder {
     /// ```rust
     /// use color_eyre::config::HookBuilder;
     ///
-    /// HookBuilder::new()
-    ///     .install()
-    ///     .unwrap();
+    /// HookBuilder::new().install().unwrap();
     /// ```
     pub fn new() -> Self {
         Self::blank()
@@ -480,9 +478,9 @@ impl HookBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use std::{panic::Location, fmt};
     /// use color_eyre::section::PanicMessage;
     /// use owo_colors::OwoColorize;
+    /// use std::{fmt, panic::Location};
     ///
     /// struct MyPanicMessage;
     ///
@@ -492,7 +490,11 @@ impl HookBuilder {
     ///     .unwrap();
     ///
     /// impl PanicMessage for MyPanicMessage {
-    ///     fn display(&self, pi: &std::panic::PanicInfo<'_>, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    ///     fn display(
+    ///         &self,
+    ///         pi: &std::panic::PanicInfo<'_>,
+    ///         f: &mut fmt::Formatter<'_>,
+    ///     ) -> fmt::Result {
     ///         writeln!(f, "{}", "The application panicked (crashed).".red())?;
     ///
     ///         // Print panic message.
@@ -513,7 +515,11 @@ impl HookBuilder {
     ///             write!(f, ":")?;
     ///             write!(f, "{}", loc.line().purple())?;
     ///
-    ///             write!(f, "\n\nConsider reporting the bug at {}", custom_url(loc, payload))?;
+    ///             write!(
+    ///                 f,
+    ///                 "\n\nConsider reporting the bug at {}",
+    ///                 custom_url(loc, payload)
+    ///             )?;
     ///         } else {
     ///             write!(f, "<unknown>")?;
     ///         }
@@ -603,7 +609,6 @@ impl HookBuilder {
     ///     })
     ///     .install()
     ///     .unwrap();
-    ///
     #[cfg(feature = "issue-url")]
     pub fn issue_filter<F>(mut self, predicate: F) -> Self
     where
@@ -643,9 +648,7 @@ impl HookBuilder {
     /// ```rust
     /// color_eyre::config::HookBuilder::default()
     ///     .add_frame_filter(Box::new(|frames| {
-    ///         let filters = &[
-    ///             "uninteresting_function",
-    ///         ];
+    ///         let filters = &["uninteresting_function"];
     ///
     ///         frames.retain(|frame| {
     ///             !filters.iter().any(|f| {
@@ -668,7 +671,7 @@ impl HookBuilder {
     }
 
     /// Install the given Hook as the global error report hook
-    pub fn install(self) -> Result<(), crate::eyre::Report> {
+    pub fn install(self) -> Result<(), crate::Report> {
         let (panic_hook, eyre_hook) = self.try_into_hooks()?;
         eyre_hook.install()?;
         panic_hook.install();
@@ -689,7 +692,7 @@ impl HookBuilder {
 
     /// Create a `PanicHook` and `EyreHook` from this `HookBuilder`.
     /// This can be used if you want to combine these handlers with other handlers.
-    pub fn try_into_hooks(self) -> Result<(PanicHook, EyreHook), crate::eyre::Report> {
+    pub fn try_into_hooks(self) -> Result<(PanicHook, EyreHook), crate::Report> {
         let theme = self.theme;
         #[cfg(feature = "issue-url")]
         let metadata = Arc::new(self.issue_metadata);
@@ -1065,8 +1068,8 @@ impl EyreHook {
     }
 
     /// Installs self as the global eyre handling hook via `eyre::set_hook`
-    pub fn install(self) -> Result<(), crate::eyre::InstallError> {
-        crate::eyre::set_hook(self.into_eyre_hook())
+    pub fn install(self) -> Result<(), crate::InstallError> {
+        crate::set_hook(self.into_eyre_hook())
     }
 
     /// Convert the self into the boxed type expected by `eyre::set_hook`.

--- a/color-eyre/src/lib.rs
+++ b/color-eyre/src/lib.rs
@@ -39,7 +39,7 @@
 //! And install the panic and error report handlers:
 //!
 //! ```rust
-//! use color_eyre::eyre::Result;
+//! use color_eyre::Result;
 //!
 //! fn main() -> Result<()> {
 //!     color_eyre::install()?;
@@ -230,7 +230,7 @@
 //! [`examples/custom_section.rs`]:
 //!
 //! ```rust
-//! use color_eyre::{eyre::eyre, SectionExt, Section, eyre::Report};
+//! use color_eyre::{eyre, Report, Section, SectionExt};
 //! use std::process::Command;
 //! use tracing::instrument;
 //!
@@ -362,11 +362,7 @@ use std::sync::Arc;
 #[doc(hidden)]
 pub use Handler as Context;
 use backtrace::Backtrace;
-pub use eyre;
-#[doc(hidden)]
-pub use eyre::Report;
-#[doc(hidden)]
-pub use eyre::Result;
+pub use eyre::*;
 pub use owo_colors;
 #[doc(hidden)]
 pub use section::Section as Help;
@@ -378,7 +374,7 @@ use tracing_error::SpanTrace;
 pub mod config;
 mod fmt;
 mod handler;
-pub(crate) mod private;
+pub(crate) mod sealed;
 pub mod section;
 mod writers;
 
@@ -446,7 +442,7 @@ pub enum ErrorKind<'a> {
 /// # Examples
 ///
 /// ```rust
-/// use color_eyre::eyre::Result;
+/// use color_eyre::Result;
 ///
 /// fn main() -> Result<()> {
 ///     color_eyre::install()?;
@@ -455,6 +451,6 @@ pub enum ErrorKind<'a> {
 ///     # Ok(())
 /// }
 /// ```
-pub fn install() -> Result<(), crate::eyre::Report> {
+pub fn install() -> Result<(), crate::Report> {
     config::HookBuilder::default().install()
 }

--- a/color-eyre/src/sealed.rs
+++ b/color-eyre/src/sealed.rs
@@ -1,4 +1,4 @@
-use crate::eyre::Report;
+use crate::Report;
 pub trait Sealed {}
 
 impl<T, E> Sealed for std::result::Result<T, E> where E: Into<Report> {}

--- a/color-eyre/src/section/help.rs
+++ b/color-eyre/src/section/help.rs
@@ -1,9 +1,5 @@
 //! Provides an extension trait for attaching `Section` to error reports.
-use crate::{
-    Section,
-    config::Theme,
-    eyre::{Report, Result},
-};
+use crate::{Report, Result, Section, config::Theme};
 use indenter::indented;
 use owo_colors::OwoColorize;
 use std::fmt::Write;

--- a/color-eyre/src/section/mod.rs
+++ b/color-eyre/src/section/mod.rs
@@ -21,7 +21,7 @@ pub(crate) mod help;
 /// # Examples
 ///
 /// ```rust
-/// use color_eyre::{eyre::eyre, SectionExt, Section, eyre::Report};
+/// use color_eyre::{eyre, Report, Section, SectionExt};
 /// use std::process::Command;
 /// use tracing::instrument;
 ///
@@ -88,7 +88,7 @@ pub trait SectionExt: Sized {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use color_eyre::{eyre::eyre, Section, SectionExt, eyre::Report};
+    /// use color_eyre::{eyre, Report, Section, SectionExt};
     ///
     /// let all_in_header = "header\n   body\n   body";
     /// let report = Err::<(), Report>(eyre!("an error occurred"))
@@ -133,7 +133,7 @@ where
 /// sections are displayed after all other sections with no extra newlines between subsequent Help
 /// sections. They consist only of a header portion and are prepended with a colored string
 /// indicating the kind of section, e.g. `Note: This might have failed due to ..."
-pub trait Section: crate::private::Sealed {
+pub trait Section: crate::sealed::Sealed {
     /// The return type of each method after adding context
     type Return;
 
@@ -149,10 +149,9 @@ pub trait Section: crate::private::Sealed {
     /// # Examples
     ///
     /// ```rust,should_panic
-    /// use color_eyre::{eyre::eyre, eyre::Report, Section};
+    /// use color_eyre::{eyre, Report, Section};
     ///
-    /// Err(eyre!("command failed"))
-    ///     .section("Please report bugs to https://real.url/bugs")?;
+    /// Err(eyre!("command failed")).section("Please report bugs to https://real.url/bugs")?;
     /// # Ok::<_, Report>(())
     /// ```
     fn section<D>(self, section: D) -> Self::Return
@@ -165,12 +164,11 @@ pub trait Section: crate::private::Sealed {
     /// # Examples
     ///
     /// ```rust
-    /// use color_eyre::{eyre::eyre, eyre::Report, Section, SectionExt};
+    /// use color_eyre::{eyre, Report, Section, SectionExt};
     ///
     /// # #[cfg(not(miri))]
     /// # {
-    /// let output = std::process::Command::new("ls")
-    ///     .output()?;
+    /// let output = std::process::Command::new("ls").output()?;
     ///
     /// let output = if !output.status.success() {
     ///     let stderr = String::from_utf8_lossy(&output.stderr);
@@ -195,7 +193,7 @@ pub trait Section: crate::private::Sealed {
     /// # Examples
     ///
     /// ```rust,should_panic
-    /// use color_eyre::{eyre::eyre, eyre::Report, Section};
+    /// use color_eyre::{eyre, Report, Section};
     /// use thiserror::Error;
     ///
     /// #[derive(Debug, Error)]
@@ -217,7 +215,7 @@ pub trait Section: crate::private::Sealed {
     /// # Examples
     ///
     /// ```rust,should_panic
-    /// use color_eyre::{eyre::eyre, eyre::Report, Section};
+    /// use color_eyre::{eyre, Report, Section};
     /// use thiserror::Error;
     ///
     /// #[derive(Debug, Error)]
@@ -240,7 +238,7 @@ pub trait Section: crate::private::Sealed {
     ///
     /// ```rust
     /// # use std::{error::Error, fmt::{self, Display}};
-    /// # use color_eyre::eyre::Result;
+    /// # use color_eyre::Result;
     /// # #[derive(Debug)]
     /// # struct FakeErr;
     /// # impl Display for FakeErr {
@@ -270,7 +268,7 @@ pub trait Section: crate::private::Sealed {
     ///
     /// ```rust
     /// # use std::{error::Error, fmt::{self, Display}};
-    /// # use color_eyre::eyre::Result;
+    /// # use color_eyre::Result;
     /// # #[derive(Debug)]
     /// # struct FakeErr;
     /// # impl Display for FakeErr {
@@ -286,8 +284,11 @@ pub trait Section: crate::private::Sealed {
     /// use color_eyre::Section as _;
     ///
     /// fallible_fn().with_note(|| {
-    ///         format!("This might have failed due to ... It has failed {} times", 100)
-    ///     })?;
+    ///     format!(
+    ///         "This might have failed due to ... It has failed {} times",
+    ///         100
+    ///     )
+    /// })?;
     /// # Ok(())
     /// # }
     /// ```

--- a/color-eyre/tests/bt_disabled.rs
+++ b/color-eyre/tests/bt_disabled.rs
@@ -1,5 +1,4 @@
 use color_eyre::eyre;
-use eyre::eyre;
 
 #[test]
 fn disabled() {

--- a/color-eyre/tests/bt_enabled.rs
+++ b/color-eyre/tests/bt_enabled.rs
@@ -1,5 +1,4 @@
 use color_eyre::eyre;
-use eyre::eyre;
 
 #[test]
 fn enabled() {

--- a/color-eyre/tests/location_disabled.rs
+++ b/color-eyre/tests/location_disabled.rs
@@ -2,7 +2,6 @@
 #[test]
 fn disabled() {
     use color_eyre::eyre;
-    use eyre::eyre;
 
     color_eyre::config::HookBuilder::default()
         .display_location_section(false)

--- a/color-eyre/tests/theme.rs
+++ b/color-eyre/tests/theme.rs
@@ -1,6 +1,6 @@
 // Note: It's recommended, not to change anything above or below (see big comment below)
 
-use color_eyre::{Section, eyre::Report};
+use color_eyre::{Report, Section};
 
 #[rustfmt::skip]
 #[derive(Debug, thiserror::Error)]

--- a/color-eyre/tests/wasm.rs
+++ b/color-eyre/tests/wasm.rs
@@ -1,7 +1,6 @@
 #[cfg(target_arch = "wasm32")]
 #[wasm_bindgen_test::wasm_bindgen_test]
 pub fn color_eyre_simple() {
-    use color_eyre::eyre::ResultExt;
     use color_eyre::*;
 
     install().expect("Failed to install color_eyre");

--- a/eyre/src/chain.rs
+++ b/eyre/src/chain.rs
@@ -21,10 +21,10 @@ impl<'a> Chain<'a> {
     /// # Example
     ///
     /// ```rust
-    /// use std::error::Error;
-    /// use std::fmt::{self, Write};
     /// use eyre::Chain;
     /// use indenter::indented;
+    /// use std::error::Error;
+    /// use std::fmt::{self, Write};
     ///
     /// fn report(error: &(dyn Error + 'static), f: &mut fmt::Formatter<'_>) -> fmt::Result {
     ///     let mut errors = Chain::new(error).enumerate();

--- a/eyre/src/lib.rs
+++ b/eyre/src/lib.rs
@@ -677,10 +677,10 @@ pub trait EyreHandler: core::any::Any + Send + Sync {
     ///
     /// ```rust
     /// use backtrace::Backtrace;
-    /// use eyre::EyreHandler;
     /// use eyre::Chain;
-    /// use std::error::Error;
+    /// use eyre::EyreHandler;
     /// use indenter::indented;
+    /// use std::error::Error;
     ///
     /// pub struct Handler {
     ///     backtrace: Backtrace,
@@ -775,7 +775,7 @@ impl DefaultHandler {
     /// # Example
     ///
     /// ```rust,should_panic
-    /// use eyre::{DefaultHandler, eyre, InstallError, Result, set_hook};
+    /// use eyre::{eyre, set_hook, DefaultHandler, InstallError, Result};
     ///
     /// fn main() -> Result<()> {
     ///     install_default().expect("default handler inexplicably already installed");
@@ -785,7 +785,6 @@ impl DefaultHandler {
     /// fn install_default() -> Result<(), InstallError> {
     ///     set_hook(Box::new(DefaultHandler::default_with))
     /// }
-    ///
     /// ```
     #[allow(unused_variables)]
     #[cfg_attr(not(feature = "auto-install"), allow(dead_code))]
@@ -1019,8 +1018,8 @@ pub type Result<T = (), E = Report> = core::result::Result<T, E>;
 /// We encourage you to write this:
 ///
 /// ```rust
+/// use eyre::{eyre, Report, ResultExt};
 /// use std::error::Error;
-/// use eyre::{ResultExt, Report, eyre};
 ///
 /// fn wrap_example(err: Result<(), Box<dyn Error + Send + Sync + 'static>>) -> Result<(), Report> {
 ///     err.map_err(|e| eyre!(e)).wrap_err("saw a downstream error")

--- a/simple-eyre/src/lib.rs
+++ b/simple-eyre/src/lib.rs
@@ -16,7 +16,7 @@
 //! # Example
 //!
 //! ```rust,should_panic
-//! use simple_eyre::eyre::{eyre, ResultExt, Report};
+//! use simple_eyre::eyre::{eyre, Report, ResultExt};
 //!
 //! fn main() -> Result<(), Report> {
 //!     simple_eyre::install()?;


### PR DESCRIPTION
color-eyre is just a thin wrapper around eyre and should behave the same. This includes the API. For this purpose all items that are publicly available in eyre should be available without another submodule from color-eyre.