### PR TITLE
fix: set workspace resolver version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
   "eyre",
   "simple-eyre",
 ]
+resolver = "3"
 
 [workspace.package]
 authors = ["Jane Lusby <jlusby@yaah.dev>"]


### PR DESCRIPTION
After the edition 2024 upgrade the resolver version defaults to version 1, but there is not reason to hold back the resolver version.

Ref: https://github.com/eyre-rs/eyre/pull/279#discussion_r3054290247