### PR TITLE
Use std `backtrace` on `stable`

### DIFF
--- a/eyre/src/lib.rs
+++ b/eyre/src/lib.rs
@@ -850,22 +850,21 @@ impl EyreHandler for DefaultHandler {
             }
         }
 
+        use std::backtrace::BacktraceStatus;
+
+        let backtrace = self.backtrace.as_ref();
+
         #[cfg(generic_member_access)]
+        // The backtrace can be stored either in the handler instance, or the error itself.
+        // If the source error has a backtrace, the handler should not capture one
+        let backtrace = backtrace.or_else(|| {
+            Some(std::error::request_ref::<Backtrace>(error).expect("backtrace capture failed"))
+        });
+
+        if let Some(backtrace) = backtrace
+            && BacktraceStatus::Captured == backtrace.status()
         {
-            use std::backtrace::BacktraceStatus;
-
-            // The backtrace can be stored either in the handler instance, or the error itself.
-            //
-            // If the source error has a backtrace, the handler should not capture one
-            let backtrace = self
-                .backtrace
-                .as_ref()
-                .or_else(|| std::error::request_ref::<Backtrace>(error))
-                .expect("backtrace capture failed");
-
-            if let BacktraceStatus::Captured = backtrace.status() {
-                write!(f, "\n\nStack backtrace:\n{}", backtrace)?;
-            }
+            write!(f, "\n\nStack backtrace:\n{}", backtrace)?;
         }
 
         Result::Ok(())

--- a/eyre/src/lib.rs
+++ b/eyre/src/lib.rs
@@ -861,10 +861,10 @@ impl EyreHandler for DefaultHandler {
             Some(std::error::request_ref::<Backtrace>(error).expect("backtrace capture failed"))
         });
 
-        if let Some(backtrace) = backtrace
-            && BacktraceStatus::Captured == backtrace.status()
-        {
-            write!(f, "\n\nStack backtrace:\n{}", backtrace)?;
+        if let Some(backtrace) = backtrace {
+            if BacktraceStatus::Captured == backtrace.status() {
+                write!(f, "\n\nStack backtrace:\n{}", backtrace)?;
+            }
         }
 
         Result::Ok(())


### PR DESCRIPTION
Only gate the `request_ref(...)` call behind `cfg(generic_member_access)`. If `self.backtrace` already exists, then we _can_ print the backtrace, even on `stable`.

Note that the `.or_else(|| Some(...))` is a little janky. This is because I wanted to maintain the current behaviour:

* If `self.backtrace` is empty (for whatever reason), don't print anything
* However, if `generic_member_access` _was_ available, then the previous behaviour was to _expect_ that a backtrace could be calculated. I chucked the `.expect` _within_ the `.or_else(...)` so that the type of `backtrace` remained `Option`, regardless of the `cfg(...)`'s state.