### PR TITLE
Eliminate pointer->reference->pointer during downcast

### DIFF
--- a/eyre/src/error.rs
+++ b/eyre/src/error.rs
@@ -605,7 +605,8 @@ where
 
 /// # Safety
 ///
-/// Requires layout of *e to match ErrorImpl<E>.
+/// Requires layout of *e to match ErrorImpl<E>. Ensures that returned pointee's layout
+/// matches `target`.
 unsafe fn object_downcast<E>(e: RefPtr<'_, ErrorImpl<()>>, target: TypeId) -> Option<NonNull<()>>
 where
     E: 'static,
@@ -622,7 +623,8 @@ where
 
 /// # Safety
 ///
-/// Requires layout of *e to match ErrorImpl<E>.
+/// Requires layout of *e to match ErrorImpl<E>. Ensures that returned pointee's layout
+/// matches `target`.
 unsafe fn object_downcast_mut<E>(
     e: MutPtr<'_, ErrorImpl<()>>,
     target: TypeId,
@@ -642,7 +644,8 @@ where
 
 /// # Safety
 ///
-/// Requires layout of *e to match ErrorImpl<ContextError<D, E>>.
+/// Requires layout of *e to match ErrorImpl<ContextError<D, E>>. Ensures that returned
+/// pointee's layout matches `target`.
 unsafe fn context_downcast<D, E>(
     e: RefPtr<'_, ErrorImpl<()>>,
     target: TypeId,
@@ -651,13 +654,16 @@ where
     D: 'static,
     E: 'static,
 {
+    let unerased = e.cast::<ErrorImpl<ContextError<D, E>>>();
     if TypeId::of::<D>() == target {
-        let unerased = e.cast::<ErrorImpl<ContextError<D, E>>>();
+        // Safety: Layout of `*unerased` matches `ErrorImpl<ContextError<D, E>>`.
         let addr = unsafe { ptr::addr_of!((*unerased.ptr.as_ptr())._object.msg) };
+        // Safety: `addr` is not null, layout matches `D`.
         Some(unsafe { NonNull::new_unchecked(addr.cast_mut()).cast::<()>() })
     } else if TypeId::of::<E>() == target {
-        let unerased = e.cast::<ErrorImpl<ContextError<D, E>>>();
+        // Safety: Layout of `*unerased` matches `ErrorImpl<ContextError<D, E>>`.
         let addr = unsafe { ptr::addr_of!((*unerased.ptr.as_ptr())._object.error) };
+        // Safety: `addr` is not null, layout matches `E`.
         Some(unsafe { NonNull::new_unchecked(addr.cast_mut()).cast::<()>() })
     } else {
         None
@@ -666,7 +672,8 @@ where
 
 /// # Safety
 ///
-/// Requires layout of *e to match ErrorImpl<ContextError<D, E>>.
+/// Requires layout of *e to match ErrorImpl<ContextError<D, E>>. Ensures that returned
+/// pointee's layout matches `target`.
 unsafe fn context_downcast_mut<D, E>(
     e: MutPtr<'_, ErrorImpl<()>>,
     target: TypeId,
@@ -675,13 +682,16 @@ where
     D: 'static,
     E: 'static,
 {
+    let unerased = e.cast::<ErrorImpl<ContextError<D, E>>>();
     if TypeId::of::<D>() == target {
-        let unerased = e.cast::<ErrorImpl<ContextError<D, E>>>();
+        // Safety: Layout of `*unerased` matches `ErrorImpl<ContextError<D, E>>`.
         let addr = unsafe { ptr::addr_of_mut!((*unerased.ptr.as_ptr())._object.msg) };
+        // Safety: `addr` is not null, layout matches `D`.
         Some(unsafe { NonNull::new_unchecked(addr).cast::<()>() })
     } else if TypeId::of::<E>() == target {
-        let unerased = e.cast::<ErrorImpl<ContextError<D, E>>>();
+        // Safety: Layout of `*unerased` matches `ErrorImpl<ContextError<D, E>>`.
         let addr = unsafe { ptr::addr_of_mut!((*unerased.ptr.as_ptr())._object.error) };
+        // Safety: `addr` is not null, layout matches `E`.
         Some(unsafe { NonNull::new_unchecked(addr).cast::<()>() })
     } else {
         None
@@ -713,7 +723,8 @@ where
 
 /// # Safety
 ///
-/// Requires layout of *e to match ErrorImpl<ContextError<D, Report>>.
+/// Requires layout of *e to match ErrorImpl<ContextError<D, Report>>. Ensures that returned pointee's
+/// layout matches `target`.
 unsafe fn context_chain_downcast<D>(
     e: RefPtr<'_, ErrorImpl<()>>,
     target: TypeId,
@@ -721,21 +732,24 @@ unsafe fn context_chain_downcast<D>(
 where
     D: 'static,
 {
+    let unerased = e.cast::<ErrorImpl<ContextError<D, Report>>>();
     if TypeId::of::<D>() == target {
-        let unerased = e.cast::<ErrorImpl<ContextError<D, Report>>>();
+        // Safety: Layout of `*unerased` matches `ErrorImpl<ContextError<D, Report>>`.
         let addr = unsafe { ptr::addr_of!((*unerased.ptr.as_ptr())._object.msg) };
+        // Safety: `addr` is not not null, layout matches `D`.
         Some(unsafe { NonNull::new_unchecked(addr.cast_mut()).cast::<()>() })
     } else {
         // Recurse down the context chain per the inner error's vtable.
-        let unerased = unsafe { e.cast::<ErrorImpl<ContextError<D, Report>>>().as_ref() };
-        let source = &unerased._object.error;
+        // Safety: Layout of *unerased matches `ErrorImpl<ContextExrror<D, Report>>`.
+        let source = unsafe { &unerased.as_ref()._object.error };
         unsafe { (source.vtable().object_downcast)(source.inner.as_ref(), target) }
     }
 }
 
 /// # Safety
 ///
-/// Requires layout of *e to match ErrorImpl<ContextError<D, Report>>.
+/// Requires layout of *e to match ErrorImpl<ContextError<D, Report>>. Ensures that returned pointee's
+/// layout matches `target`.
 unsafe fn context_chain_downcast_mut<D>(
     e: MutPtr<'_, ErrorImpl<()>>,
     target: TypeId,
@@ -743,14 +757,14 @@ unsafe fn context_chain_downcast_mut<D>(
 where
     D: 'static,
 {
+    let unerased = e.cast::<ErrorImpl<ContextError<D, Report>>>();
     if TypeId::of::<D>() == target {
-        let unerased = e.cast::<ErrorImpl<ContextError<D, Report>>>();
         let addr = unsafe { ptr::addr_of_mut!((*unerased.ptr.as_ptr())._object.msg) };
         Some(unsafe { NonNull::new_unchecked(addr).cast::<()>() })
     } else {
         // Recurse down the context chain per the inner error's vtable.
-        let unerased = unsafe { e.cast::<ErrorImpl<ContextError<D, Report>>>().into_mut() };
-        let source = &mut unerased._object.error;
+        // Safety: Layout of *unerased matches `ErrorImpl<ContextExrror<D, Report>>`.
+        let source = unsafe { &mut unerased.into_mut()._object.error };
         unsafe { (source.vtable().object_downcast_mut)(source.inner.as_mut(), target) }
     }
 }

--- a/eyre/src/error.rs
+++ b/eyre/src/error.rs
@@ -652,13 +652,13 @@ where
     E: 'static,
 {
     if TypeId::of::<D>() == target {
-        let unerased = unsafe { e.cast::<ErrorImpl<ContextError<D, E>>>().as_ref() };
-        let addr = NonNull::from(&unerased._object.msg).cast::<()>();
-        Some(addr)
+        let unerased = e.cast::<ErrorImpl<ContextError<D, E>>>();
+        let addr = unsafe { ptr::addr_of!((*unerased.ptr.as_ptr())._object.msg) };
+        Some(unsafe { NonNull::new_unchecked(addr.cast_mut()).cast::<()>() })
     } else if TypeId::of::<E>() == target {
-        let unerased = unsafe { e.cast::<ErrorImpl<ContextError<D, E>>>().as_ref() };
-        let addr = NonNull::from(&unerased._object.error).cast::<()>();
-        Some(addr)
+        let unerased = e.cast::<ErrorImpl<ContextError<D, E>>>();
+        let addr = unsafe { ptr::addr_of!((*unerased.ptr.as_ptr())._object.error) };
+        Some(unsafe { NonNull::new_unchecked(addr.cast_mut()).cast::<()>() })
     } else {
         None
     }
@@ -676,13 +676,13 @@ where
     E: 'static,
 {
     if TypeId::of::<D>() == target {
-        let unerased = unsafe { e.cast::<ErrorImpl<ContextError<D, E>>>().into_mut() };
-        let addr = NonNull::from(&unerased._object.msg).cast::<()>();
-        Some(addr)
+        let unerased = e.cast::<ErrorImpl<ContextError<D, E>>>();
+        let addr = unsafe { ptr::addr_of_mut!((*unerased.ptr.as_ptr())._object.msg) };
+        Some(unsafe { NonNull::new_unchecked(addr).cast::<()>() })
     } else if TypeId::of::<E>() == target {
-        let unerased = unsafe { e.cast::<ErrorImpl<ContextError<D, E>>>().into_mut() };
-        let addr = NonNull::from(&mut unerased._object.error).cast::<()>();
-        Some(addr)
+        let unerased = e.cast::<ErrorImpl<ContextError<D, E>>>();
+        let addr = unsafe { ptr::addr_of_mut!((*unerased.ptr.as_ptr())._object.error) };
+        Some(unsafe { NonNull::new_unchecked(addr).cast::<()>() })
     } else {
         None
     }
@@ -721,12 +721,13 @@ unsafe fn context_chain_downcast<D>(
 where
     D: 'static,
 {
-    let unerased = unsafe { e.cast::<ErrorImpl<ContextError<D, Report>>>().as_ref() };
     if TypeId::of::<D>() == target {
-        let addr = NonNull::from(&unerased._object.msg).cast::<()>();
-        Some(addr)
+        let unerased = e.cast::<ErrorImpl<ContextError<D, Report>>>();
+        let addr = unsafe { ptr::addr_of!((*unerased.ptr.as_ptr())._object.msg) };
+        Some(unsafe { NonNull::new_unchecked(addr.cast_mut()).cast::<()>() })
     } else {
         // Recurse down the context chain per the inner error's vtable.
+        let unerased = unsafe { e.cast::<ErrorImpl<ContextError<D, Report>>>().as_ref() };
         let source = &unerased._object.error;
         unsafe { (source.vtable().object_downcast)(source.inner.as_ref(), target) }
     }
@@ -742,12 +743,13 @@ unsafe fn context_chain_downcast_mut<D>(
 where
     D: 'static,
 {
-    let unerased = unsafe { e.cast::<ErrorImpl<ContextError<D, Report>>>().into_mut() };
     if TypeId::of::<D>() == target {
-        let addr = NonNull::from(&unerased._object.msg).cast::<()>();
-        Some(addr)
+        let unerased = e.cast::<ErrorImpl<ContextError<D, Report>>>();
+        let addr = unsafe { ptr::addr_of_mut!((*unerased.ptr.as_ptr())._object.msg) };
+        Some(unsafe { NonNull::new_unchecked(addr).cast::<()>() })
     } else {
         // Recurse down the context chain per the inner error's vtable.
+        let unerased = unsafe { e.cast::<ErrorImpl<ContextError<D, Report>>>().into_mut() };
         let source = &mut unerased._object.error;
         unsafe { (source.vtable().object_downcast_mut)(source.inner.as_mut(), target) }
     }

--- a/eyre/tests/test_context.rs
+++ b/eyre/tests/test_context.rs
@@ -171,3 +171,28 @@ fn test_unsuccessful_downcast() {
     drop(err);
     assert!(dropped.all());
 }
+
+#[test]
+fn test_downcast_mut() {
+    maybe_install_handler().unwrap();
+
+    let (mut err, dropped) = make_chain();
+
+    err.downcast_mut::<HighLevel>().unwrap().message = "high context";
+    err.downcast_mut::<MidLevel>().unwrap().message = "mid context";
+    err.downcast_mut::<LowLevel>().unwrap().message = "low error";
+
+    assert_eq!(
+        err.downcast_ref::<HighLevel>().unwrap().message,
+        "high context",
+    );
+    assert_eq!(
+        err.downcast_ref::<MidLevel>().unwrap().message,
+        "mid context",
+    );
+    assert_eq!(err.downcast_ref::<LowLevel>().unwrap().message, "low error");
+
+    assert!(dropped.none());
+    drop(err);
+    assert!(dropped.all());
+}


### PR DESCRIPTION
Based on <https://github.com/dtolnay/anyhow/pull/452/commits>. Fixes the same unsoundness in the same way. The included unit test fails under MIRI without the fix and passes afterward.

Fixes #285.