### PR TITLE
Make tests compatible with v0 symbol mangling

### DIFF
--- a/color-eyre/src/config.rs
+++ b/color-eyre/src/config.rs
@@ -288,9 +288,6 @@ impl fmt::Display for SourceSection<'_> {
 impl Frame {
     fn is_dependency_code(&self) -> bool {
         const SYM_PREFIXES: &[&str] = &[
-            "std::",
-            "core::",
-            "backtrace::backtrace::",
             "_rust_begin_unwind",
             "color_traceback::",
             "__rust_",
@@ -307,7 +304,11 @@ impl Frame {
 
         // Inspect name.
         if let Some(ref name) = self.name {
-            if SYM_PREFIXES.iter().any(|x| name.starts_with(x)) {
+            if starts_with_crate_path(name, "std")
+                || starts_with_crate_path(name, "core")
+                || starts_with_crate_path_prefix(name, "backtrace", "backtrace::")
+                || SYM_PREFIXES.iter().any(|x| name.starts_with(x))
+            {
                 return true;
             }
         }
@@ -323,6 +324,7 @@ impl Frame {
         if let Some(ref filename) = self.filename {
             let filename = filename.to_string_lossy();
             if FILE_PREFIXES.iter().any(|x| filename.starts_with(x))
+                || filename.contains("/lib/rustlib/src/rust/library/")
                 || filename.contains("/.cargo/registry/src/")
             {
                 return true;
@@ -355,7 +357,13 @@ impl Frame {
         ];
 
         match self.name.as_ref() {
-            Some(name) => SYM_PREFIXES.iter().any(|x| name.starts_with(x)),
+            Some(name) => {
+                starts_with_crate_path_prefix(name, "core", "result::unwrap_failed")
+                    || starts_with_crate_path_prefix(name, "core", "option::expect_none_failed")
+                    || starts_with_crate_path_prefix(name, "core", "panicking::panic_fmt")
+                    || starts_with_crate_path_prefix(name, "std", "panicking::begin_panic")
+                    || SYM_PREFIXES.iter().any(|x| name.starts_with(x))
+            }
             None => false,
         }
     }
@@ -374,7 +382,20 @@ impl Frame {
             _ => return false,
         };
 
-        if SYM_PREFIXES.iter().any(|x| name.starts_with(x)) {
+        if starts_with_crate_path_prefix(name, "std", "rt::lang_start::")
+            || starts_with_crate_path_prefix(
+                name,
+                "std",
+                "sys_common::backtrace::__rust_begin_short_backtrace",
+            )
+            || starts_with_crate_path_prefix(
+                name,
+                "std",
+                "sys::backtrace::__rust_begin_short_backtrace",
+            )
+            || starts_with_crate_path_prefix(name, "test", "run_test::run_test_inner::")
+            || SYM_PREFIXES.iter().any(|x| name.starts_with(x))
+        {
             return true;
         }
 
@@ -773,23 +794,40 @@ fn default_frame_filter(frames: &mut Vec<&Frame>) {
 }
 
 fn eyre_frame_filters(frames: &mut Vec<&Frame>) {
-    let filters = &[
-        "<color_eyre::Handler as eyre::EyreHandler>::default",
-        "eyre::",
-        "color_eyre::",
-    ];
+    let filters = &["<color_eyre::Handler as eyre::EyreHandler>::default"];
 
     frames.retain(|frame| {
-        !filters.iter().any(|f| {
-            let name = if let Some(name) = frame.name.as_ref() {
-                name.as_str()
-            } else {
-                return true;
-            };
+        let name = if let Some(name) = frame.name.as_ref() {
+            name.as_str()
+        } else {
+            return true;
+        };
 
-            name.starts_with(f)
-        })
+        !filters.iter().any(|f| name.starts_with(f))
+            && !starts_with_crate_path(name, "eyre")
+            && !starts_with_crate_path(name, "color_eyre")
     });
+}
+
+fn starts_with_crate_path(name: &str, krate: &str) -> bool {
+    strip_crate_path_prefix(name, krate).is_some()
+}
+
+fn starts_with_crate_path_prefix(name: &str, krate: &str, path_prefix: &str) -> bool {
+    strip_crate_path_prefix(name, krate).is_some_and(|path| path.starts_with(path_prefix))
+}
+
+fn strip_crate_path_prefix<'a>(name: &'a str, krate: &str) -> Option<&'a str> {
+    let name = name.strip_prefix('<').unwrap_or(name);
+    let rest = name.strip_prefix(krate)?;
+
+    if let Some(rest) = rest.strip_prefix("::") {
+        return Some(rest);
+    }
+
+    let rest = rest.strip_prefix('[')?;
+    let disambiguator_end = rest.find(']')?;
+    rest[disambiguator_end + 1..].strip_prefix("::")
 }
 
 struct DefaultPanicMessage(Theme);

--- a/color-eyre/tests/theme.rs
+++ b/color-eyre/tests/theme.rs
@@ -38,7 +38,6 @@ static ERROR_FILE_NAME: &str = "theme_error_control_spantrace.txt";
 #[cfg(all(feature = "capture-spantrace", feature = "track-caller",))]
 static ERROR_FILE_NAME: &str = "theme_error_control.txt";
 
-#[rustversion::attr(nightly, ignore)]
 #[test]
 #[cfg(not(miri))]
 fn test_error_backwards_compatibility() {
@@ -101,7 +100,6 @@ static PANIC_FILE_NAME: &str = "theme_panic_control_no_spantrace.txt";
 static PANIC_FILE_NAME: &str = "theme_panic_control.txt";
 
 // The following tests the installed panic handler
-#[rustversion::attr(nightly, ignore)]
 #[test]
 #[allow(unused_mut)]
 #[allow(clippy::vec_init_then_push)]
@@ -128,6 +126,7 @@ fn test_panic_backwards_compatibility() {
         .args(&features)
         .env("RUSTFLAGS", "-Awarnings")
         .env("CARGO_FUTURE_INCOMPAT_REPORT_FREQUENCY", "never")
+        .env_remove("NO_COLOR")
         .output()
         .expect("failed to execute process");
     let target = String::from_utf8(output.stderr).expect("failed to convert output to `String`");
@@ -173,13 +172,42 @@ fn test_backwards_compatibility(target: String, file_name: &str) {
     }
 
     fn normalize_backtrace(input: &str) -> String {
+        fn contains_crate_path(input: &str, krate: &str, path_prefix: &str) -> bool {
+            input.match_indices(krate).any(|(idx, _)| {
+                let rest = &input[idx + krate.len()..];
+
+                if rest
+                    .strip_prefix("::")
+                    .is_some_and(|path| path.starts_with(path_prefix))
+                {
+                    return true;
+                }
+
+                let Some(rest) = rest.strip_prefix('[') else {
+                    return false;
+                };
+                let Some(disambiguator_end) = rest.find(']') else {
+                    return false;
+                };
+
+                rest[disambiguator_end + 1..]
+                    .strip_prefix("::")
+                    .is_some_and(|path| path.starts_with(path_prefix))
+            })
+        }
+
+        fn is_test_closure_line(line: &str) -> bool {
+            line.contains("test_error_backwards_compatibility::closure")
+                || line.contains("test_error_backwards_compatibility::{{closure}}")
+                || line.contains("test_error_backwards_compatibility::{closure")
+        }
+
         input
             .lines()
             .take_while(|v| {
-                !v.contains("core::panic")
-                    && !v.contains("theme_test_helper::main")
-                    && !v.contains("theme::test_error_backwards_compatibility::closure")
-                    && !v.contains("theme::test_error_backwards_compatibility::{{closure}}")
+                !contains_crate_path(v, "core", "panic")
+                    && !contains_crate_path(v, "theme_test_helper", "main")
+                    && !is_test_closure_line(v)
             })
             .collect::<Vec<_>>()
             .join("\n")
@@ -255,7 +283,10 @@ fn test_backwards_compatibility(target: String, file_name: &str) {
 }
 
 fn setup() {
-    unsafe { std::env::set_var("RUST_LIB_BACKTRACE", "1") };
+    unsafe {
+        std::env::set_var("RUST_LIB_BACKTRACE", "1");
+        std::env::remove_var("NO_COLOR");
+    };
 
     #[cfg(feature = "capture-spantrace")]
     {


### PR DESCRIPTION
Fixes #287. Arguably.

I reiterate my position that these tests are a brittle kludge. This PR does not make them any better, and I think it makes them worse. If I were a maintainer and received this, I would reject it. It has only one thing going in its favor, which is that will make tests pass again on today's MSRV, stable, beta, and nightly. I make you no promises about tomorrow's.