### PR TITLE
fix: correct typos in comments and doc strings

### DIFF
--- a/color-eyre/src/config.rs
+++ b/color-eyre/src/config.rs
@@ -640,7 +640,7 @@ impl HookBuilder {
         self
     }
 
-    /// Configures the enviroment varible info section and whether or not it is displayed
+    /// Configures the environment variable info section and whether or not it is displayed
     pub fn display_env_section(mut self, cond: bool) -> Self {
         self.display_env_section = cond;
         self

--- a/color-eyre/src/fmt.rs
+++ b/color-eyre/src/fmt.rs
@@ -1,4 +1,4 @@
-//! Module for new types that isolate complext formatting
+//! Module for new types that isolate complex formatting
 use std::fmt;
 
 use owo_colors::OwoColorize;

--- a/color-eyre/src/lib.rs
+++ b/color-eyre/src/lib.rs
@@ -78,7 +78,7 @@
 //!
 //! ### Improving perf on debug builds
 //!
-//! In debug mode `color-eyre` behaves noticably worse than `eyre`. This is caused
+//! In debug mode `color-eyre` behaves noticeably worse than `eyre`. This is caused
 //! by the fact that `eyre` uses `std::backtrace::Backtrace` instead of
 //! `backtrace::Backtrace`. The std version of backtrace is precompiled with
 //! optimizations, this means that whether or not you're in debug mode doesn't

--- a/color-eyre/tests/bt_disabled.rs
+++ b/color-eyre/tests/bt_disabled.rs
@@ -8,7 +8,7 @@ fn disabled() {
         .install()
         .unwrap();
 
-    let report = eyre!("error occured");
+    let report = eyre!("error occurred");
 
     let report = format!("{report:?}");
     assert!(!report.contains("RUST_BACKTRACE"));

--- a/color-eyre/tests/bt_enabled.rs
+++ b/color-eyre/tests/bt_enabled.rs
@@ -8,7 +8,7 @@ fn enabled() {
         .install()
         .unwrap();
 
-    let report = eyre!("error occured");
+    let report = eyre!("error occurred");
 
     let report = format!("{report:?}");
     assert!(report.contains("RUST_BACKTRACE"));

--- a/color-eyre/tests/location_disabled.rs
+++ b/color-eyre/tests/location_disabled.rs
@@ -9,7 +9,7 @@ fn disabled() {
         .install()
         .unwrap();
 
-    let report = eyre!("error occured");
+    let report = eyre!("error occurred");
 
     let report = format!("{report:?}");
     assert!(!report.contains("Location:"));

--- a/color-eyre/tests/theme.rs
+++ b/color-eyre/tests/theme.rs
@@ -270,7 +270,7 @@ fn test_backwards_compatibility(target: String, file_name: &str) {
 
         ## Compare `ansi_parser` tokens
 
-        If you fixed all potential problems above, and the test still failes, compare the actual ANSI escape sequences:
+        If you fixed all potential problems above, and the test still fails, compare the actual ANSI escape sequences:
 
         1) Activate "CURRENT ANSI PARSER OUTPUT" and "CURRENT ANSI PARSER OUTPUT" above
 

--- a/eyre/src/error.rs
+++ b/eyre/src/error.rs
@@ -71,7 +71,7 @@ impl Report {
     }
 
     #[cfg_attr(track_caller, track_caller)]
-    /// Creates a new error from an implementor of [`std::error::Error`]
+    /// Creates a new error from an implementer of [`std::error::Error`]
     pub(crate) fn from_std<E>(error: E) -> Self
     where
         E: StdError + Send + Sync + 'static,
@@ -827,7 +827,7 @@ impl<E> ErrorImpl<E> {
     fn erase(&self) -> RefPtr<'_, ErrorImpl<()>> {
         // Erase the concrete type of E but preserve the vtable in self.vtable
         // for manipulating the resulting thin pointer. This is analogous to an
-        // unsize coersion.
+        // unsize coercion.
         RefPtr::new(self).cast()
     }
 }

--- a/eyre/src/lib.rs
+++ b/eyre/src/lib.rs
@@ -1227,7 +1227,7 @@ pub trait OptionExt<T>: context::private::Sealed {
 /// fn get_thing(mut things: impl Iterator<Item = u32>) -> eyre::Result<u32> {
 ///     things
 ///         .find(|&thing| thing == 42)
-///         .context("the thing wasnt in the list")
+///         .context("the thing wasn't in the list")
 /// }
 /// ```
 ///
@@ -1239,7 +1239,7 @@ pub trait OptionExt<T>: context::private::Sealed {
 /// fn get_thing(mut things: impl Iterator<Item = u32>) -> eyre::Result<u32> {
 ///     things
 ///         .find(|&thing| thing == 42)
-///         .ok_or_else(|| eyre!("the thing wasnt in the list"))
+///         .ok_or_else(|| eyre!("the thing wasn't in the list"))
 /// }
 /// ```
 #[cfg(feature = "anyhow")]


### PR DESCRIPTION
Fix spelling errors found by [codespell](https://github.com/codespell-project/codespell) across `eyre` and `color-eyre`.

## Changes

| File | Typo | Fix |
|------|------|-----|
| `eyre/src/error.rs` | `implementor` | `implementer` |
| `eyre/src/error.rs` | `coersion` | `coercion` |
| `eyre/src/lib.rs` | `wasnt` (x2) | `wasn't` |
| `color-eyre/src/config.rs` | `enviroment varible` | `environment variable` |
| `color-eyre/src/fmt.rs` | `complext` | `complex` |
| `color-eyre/src/lib.rs` | `noticably` | `noticeably` |
| `color-eyre/tests/bt_disabled.rs` | `occured` | `occurred` |
| `color-eyre/tests/bt_enabled.rs` | `occured` | `occurred` |
| `color-eyre/tests/location_disabled.rs` | `occured` | `occurred` |
| `color-eyre/tests/theme.rs` | `failes` | `fails` |

All changes are in comments, doc strings, and string literals — no logic is affected.