### PR TITLE
Don't emit trailing semicolon from `bail!`

### DIFF
--- a/eyre/src/macros.rs
+++ b/eyre/src/macros.rs
@@ -52,13 +52,13 @@
 #[clippy::format_args]
 macro_rules! bail {
     ($msg:literal $(,)?) => {
-        return $crate::private::Err($crate::eyre!($msg));
+        return $crate::private::Err($crate::eyre!($msg))
     };
     ($err:expr $(,)?) => {
-        return $crate::private::Err($crate::eyre!($err));
+        return $crate::private::Err($crate::eyre!($err))
     };
     ($fmt:expr, $($arg:tt)*) => {
-        return $crate::private::Err($crate::eyre!($fmt, $($arg)*));
+        return $crate::private::Err($crate::eyre!($fmt, $($arg)*))
     };
 }
 


### PR DESCRIPTION
Using `bail` in expression position (e.g. a match arm) leads to a warning on recent Rust nightlies, which might be turned into an error soon (see https://github.com/rust-lang/rust/pull/159218 ).

This commit fixes this by just removing the semicolon on the emitted `return` statement. This is the same fix that was already applied in `anyhow` in https://github.com/dtolnay/anyhow/pull/120

Fixes https://github.com/eyre-rs/eyre/issues/293